### PR TITLE
improvement(Gateway): remove game node when connection is lost

### DIFF
--- a/core/src/main/kotlin/fr/rob/core/network/v2/AbstractClient.kt
+++ b/core/src/main/kotlin/fr/rob/core/network/v2/AbstractClient.kt
@@ -12,4 +12,6 @@ abstract class AbstractClient<T> : ClientInterface<T> {
     override fun send(message: Any) {
         session.send(message)
     }
+
+    override fun onConnectionClosed() {}
 }

--- a/core/src/main/kotlin/fr/rob/core/network/v2/ClientInterface.kt
+++ b/core/src/main/kotlin/fr/rob/core/network/v2/ClientInterface.kt
@@ -9,6 +9,7 @@ interface ClientInterface<T> {
     val responseStack: ResponseStackInterface
 
     fun onConnectionEstablished(session: Session)
+    fun onConnectionClosed()
     fun onPacketReceived(packet: T)
 
     fun send(message: Any)

--- a/core/src/main/kotlin/fr/rob/core/network/v2/netty/client/NettyChannelHandler.kt
+++ b/core/src/main/kotlin/fr/rob/core/network/v2/netty/client/NettyChannelHandler.kt
@@ -6,7 +6,7 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.util.ReferenceCountUtil
 
-abstract class NettyChannelHandler<T>(private val client: ClientInterface<T>) : ChannelInboundHandlerAdapter() {
+abstract class NettyChannelHandler<T>(protected val client: ClientInterface<T>) : ChannelInboundHandlerAdapter() {
 
     abstract fun createPacketFromMessage(msg: Any): T
     abstract fun createSessionSocket(ctx: ChannelHandlerContext): SessionSocketInterface

--- a/gateway/src/main/kotlin/fr/rob/gateway/extension/game/GameNodeBuilder.kt
+++ b/gateway/src/main/kotlin/fr/rob/gateway/extension/game/GameNodeBuilder.kt
@@ -6,7 +6,7 @@ import fr.rob.gateway.network.Gateway
 
 class GameNodeBuilder(private val gateway: Gateway, private val logger: LoggerInterface) {
     fun build(label: String, hostname: String, port: Int): GameNode {
-        val client = GameNodeClient(gateway, logger)
+        val client = GameNodeClient(label, gateway, logger)
         val process = GameNodeNettyClient(hostname, port, client)
         val gameNode = GameNode(label, client)
 

--- a/gateway/src/main/kotlin/fr/rob/gateway/extension/game/GameNodeClient.kt
+++ b/gateway/src/main/kotlin/fr/rob/gateway/extension/game/GameNodeClient.kt
@@ -14,6 +14,7 @@ import fr.rob.gateway.network.Gateway
 import fr.rob.gateway.network.GatewaySession
 
 class GameNodeClient(
+    private val nodeLabel: String,
     private val gateway: Gateway,
     private val logger: LoggerInterface
 ) : AbstractClient<Packet>() {
@@ -24,6 +25,12 @@ class GameNodeClient(
 
     override fun onConnectionEstablished(session: Session) {
         this.session = session
+    }
+
+    override fun onConnectionClosed() {
+        logger.error("Connection lost with game node $nodeLabel, closing client connections...")
+
+        gateway.gameNodes.findByLabel(nodeLabel).ifPresent { gameNode -> gateway.closeGameNodeConnection(gameNode) }
     }
 
     override fun onPacketReceived(packet: Packet) {

--- a/gateway/src/main/kotlin/fr/rob/gateway/extension/game/network/netty/client/GameNodeNettyChannelHandler.kt
+++ b/gateway/src/main/kotlin/fr/rob/gateway/extension/game/network/netty/client/GameNodeNettyChannelHandler.kt
@@ -12,4 +12,8 @@ class GameNodeNettyChannelHandler(client: ClientInterface<GamePacket>) : NettyCh
 
     override fun createSessionSocket(ctx: ChannelHandlerContext): SessionSocketInterface =
         NettySessionSocket(ctx.channel())
+
+    override fun channelInactive(ctx: ChannelHandlerContext) {
+        client.onConnectionClosed()
+    }
 }

--- a/gateway/src/main/kotlin/fr/rob/gateway/extension/realm/RealmService.kt
+++ b/gateway/src/main/kotlin/fr/rob/gateway/extension/realm/RealmService.kt
@@ -12,7 +12,6 @@ import fr.rob.gateway.network.GatewaySession
 import fr.rob.world.api.grpc.character.CharacterInfo
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
-import java.util.Optional
 
 class RealmService(
     private val gateway: Gateway,
@@ -39,7 +38,7 @@ class RealmService(
     }
 
     private fun retrieveGameNodeOrCreate(nodeLabel: String, hostname: String, port: Int, gameNodes: GameNodes): GameNode {
-        val gameNodeContainer = retrieveGameNodeFromLabel(nodeLabel, gameNodes)
+        val gameNodeContainer = gameNodes.findByLabel(nodeLabel)
 
         if (gameNodeContainer.isPresent) {
             return gameNodeContainer.get()
@@ -49,16 +48,6 @@ class RealmService(
         gameNodes.addNode(gameNode)
 
         return gameNode
-    }
-
-    private fun retrieveGameNodeFromLabel(nodeLabel: String, gameNodes: GameNodes): Optional<GameNode> {
-        for (gameNode in gameNodes.getNodes()) {
-            if (gameNode.label == nodeLabel) {
-                return Optional.of(gameNode)
-            }
-        }
-
-        return Optional.empty()
     }
 
     fun reserveCharacterForSession(session: GatewaySession, character: CharacterInfo) {

--- a/gateway/src/main/kotlin/fr/rob/gateway/extension/realm/gamenode/GameNodes.kt
+++ b/gateway/src/main/kotlin/fr/rob/gateway/extension/realm/gamenode/GameNodes.kt
@@ -1,13 +1,27 @@
 package fr.rob.gateway.extension.realm.gamenode
 
 import fr.rob.gateway.extension.game.GameNode
+import java.util.Collections
+import java.util.Optional
 
 class GameNodes {
-    private val nodes = ArrayList<GameNode>()
+    private val nodes = Collections.synchronizedList(ArrayList<GameNode>())
 
     fun addNode(node: GameNode) {
         nodes.add(node)
     }
 
-    fun getNodes(): List<GameNode> = nodes
+    fun removeGameNode(gameNode: GameNode) {
+        nodes.remove(gameNode)
+    }
+
+    fun findByLabel(nodeLabel: String): Optional<GameNode> {
+        for (gameNode in nodes) {
+            if (gameNode.label == nodeLabel) {
+                return Optional.of(gameNode)
+            }
+        }
+
+        return Optional.empty()
+    }
 }

--- a/gateway/src/main/kotlin/fr/rob/gateway/network/Gateway.kt
+++ b/gateway/src/main/kotlin/fr/rob/gateway/network/Gateway.kt
@@ -5,6 +5,7 @@ import fr.rob.core.network.v2.Server
 import fr.rob.core.network.v2.session.Session
 import fr.rob.core.network.v2.session.SessionSocketInterface
 import fr.rob.gateway.extension.ExtensionInterface
+import fr.rob.gateway.extension.game.GameNode
 import fr.rob.gateway.extension.realm.gamenode.GameNodes
 import fr.rob.gateway.network.dispatcher.PacketDispatcherInterface
 
@@ -19,6 +20,12 @@ class Gateway : Server<Packet>() {
         dispatchers.add(extension.createDispatcher(this))
 
         return this
+    }
+
+    fun closeGameNodeConnection(gameNode: GameNode) {
+        findSessionsByGameNode(gameNode).forEach { session -> session.kick() }
+
+        gameNodes.removeGameNode(gameNode)
     }
 
     override fun onPacketReceived(session: Session, packet: Packet) {
@@ -59,5 +66,19 @@ class Gateway : Server<Packet>() {
 
     fun registerSessionIdentifier(gatewaySession: GatewaySession) {
         sessionIdentifiers[gatewaySession.accountId!!] = gatewaySession.id
+    }
+
+    private fun findSessionsByGameNode(gameNode: GameNode): List<GatewaySession> {
+        val matchingSession = ArrayList<GatewaySession>()
+
+        sessionIdentifiers.forEach { (_, sessionId) ->
+            val session = sessionFromIdentifier(sessionId) as GatewaySession
+
+            if (session.currentGameNode == gameNode) {
+                matchingSession.add(session)
+            }
+        }
+
+        return matchingSession
     }
 }


### PR DESCRIPTION
It allows to restart the same game node multiple times without relaunching the gateway