### PR TITLE
feat: add chunk-based entity activation system

### DIFF
--- a/servers/game/src/main/kotlin/fr/rob/game/App.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/App.kt
@@ -7,6 +7,7 @@ import fr.rob.game.character.waitingroom.CharacterWaitingRoom
 import fr.rob.game.config.DB_REALM
 import fr.rob.game.config.DB_WORLD
 import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
 import fr.rob.game.node.NodeBuilder
 import fr.rob.game.map.MapManager
 import fr.rob.game.world.DelayedUpdateQueue
@@ -21,6 +22,7 @@ class App(private val config: GameConfig) : KoinComponent {
 
     private val loggerFactory: LoggerFactoryInterface by inject()
     private val instanceManager: InstanceManager by inject()
+    private val instanceUpdateService: InstanceUpdateService by inject()
     private val mapManager: MapManager by inject()
     private val connectionPoolManager: ConnectionPoolManager by inject { parametersOf(6) } // @todo Change this hard coded value
     private val characterWaitingRoom: CharacterWaitingRoom by inject()
@@ -39,6 +41,7 @@ class App(private val config: GameConfig) : KoinComponent {
             delayedUpdateQueue,
             FakeInstanceBuilder(mapManager, instanceManager),
             instanceManager,
+            instanceUpdateService,
             characterWaitingRoom,
         ).run(config.nodesConfig.nodeConfig)
     }

--- a/servers/game/src/main/kotlin/fr/rob/game/Supervisor.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/Supervisor.kt
@@ -11,6 +11,7 @@ import fr.rob.core.network.v2.session.SessionSocketUpdater
 import fr.rob.game.instance.FakeInstanceBuilder
 import fr.rob.game.character.waitingroom.CharacterWaitingRoom
 import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
 import fr.rob.game.node.NodeBuilder
 import fr.rob.game.node.NodeConfig
 import fr.rob.game.world.DelayedUpdateQueue
@@ -33,6 +34,7 @@ class Supervisor(
     private val delayedUpdateQueue: DelayedUpdateQueue,
     private val fakeInstanceBuilder: FakeInstanceBuilder,
     private val instanceManager: InstanceManager,
+    private val instanceUpdateService: InstanceUpdateService,
     private val characterWaitingRoom: CharacterWaitingRoom,
 ) {
 
@@ -62,7 +64,7 @@ class Supervisor(
         rpcServer.start()
 
         thread(true) {
-            val world = World(instanceManager, worldPacketQueue, delayedUpdateQueue)
+            val world = World(instanceManager, instanceUpdateService, worldPacketQueue, delayedUpdateQueue)
 
             val worldUpdater = WorldUpdater(
                 world,

--- a/servers/game/src/main/kotlin/fr/rob/game/config/definitions.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/config/definitions.kt
@@ -29,6 +29,7 @@ import fr.rob.game.entity.movement.spline.SplineMovementBrainInterface
 import fr.rob.game.entity.movement.spline.UnitySplineMovementBrain
 import fr.rob.game.entity.template.Creature
 import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
 import fr.rob.game.player.InstanceFinderInterface
 import fr.rob.game.player.PlayerFactory
 import fr.rob.game.map.grid.GridBuilder
@@ -80,6 +81,7 @@ val globalModule =
         single<EventManagerInterface> { EventManager() }
         singleOf<LoggerFactoryInterface> { LoggerFactory({}.javaClass.classLoader.getResourceAsStream("log4j.config.xml")!!) }
         single { InstanceManager(GridBuilder(GridConstraintChecker())) }
+        single { InstanceUpdateService(get()) }
         single<InstanceFinderInterface> { FakeInstanceFinder(get()) }
     }
 
@@ -119,7 +121,7 @@ val opcodeModule =
             )
         }
 
-        single { ObjectManager(get()) }
+        single { ObjectManager(get(), get()) }
 
         single { DelayedUpdateQueue() }
 

--- a/servers/game/src/main/kotlin/fr/rob/game/entity/ObjectManager.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/entity/ObjectManager.kt
@@ -1,15 +1,18 @@
 package fr.rob.game.entity
 
 import fr.rob.game.entity.OutOfBoundsException
+import fr.rob.game.entity.event.AddedIntoWorldEvent
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.entity.guid.ObjectGuid.LowGuid
 import fr.rob.game.entity.guid.ObjectGuidGenerator
+import fr.rob.game.instance.InstanceManager
 import fr.rob.game.instance.MapInstance
 import fr.rob.game.map.grid.Grid
 import fr.rob.game.map.Map
 
 class ObjectManager(
     private val objectGuidGenerator: ObjectGuidGenerator,
+    private val instanceManager: InstanceManager,
 ) {
     fun spawnObject(lowGuid: LowGuid, position: Position, instance: MapInstance): WorldObject? {
         // Check out of bounds
@@ -30,13 +33,31 @@ class ObjectManager(
         return createWorldObject(guid, instance, position)
     }
 
+    fun addEntityIntoInstance(worldObject: WorldObject, instance: MapInstance, position: Position) {
+        worldObject.mapInstance = instance
+        worldObject.position = position
+        worldObject.isInWorld = true
+
+        instance.pushEvent(AddedIntoWorldEvent(worldObject))
+        instance.grid.addWorldObject(worldObject)
+
+        val chunkManager = instanceManager.getChunkManager(instance.id)
+        val chunkId = chunkManager.getChunkIdForPosition(position)
+        worldObject.cachedChunkId = chunkId
+        chunkManager.registerEntity(worldObject, chunkId)
+
+        if (worldObject.guid.isPlayer()) {
+            chunkManager.onPlayerEntered(worldObject)
+        }
+    }
+
     private fun isObjectAlreadyInGrid(guid: ObjectGuid, grid: Grid): Boolean =
         grid.findObjectByGuid(guid) != null
 
     private fun createWorldObject(guid: ObjectGuid, instance: MapInstance, position: Position): WorldObject {
         val worldObject = WorldObject(guid)
 
-        worldObject.addIntoInstance(instance, position)
+        addEntityIntoInstance(worldObject, instance, position)
 
         return worldObject
     }

--- a/servers/game/src/main/kotlin/fr/rob/game/entity/WorldObject.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/entity/WorldObject.kt
@@ -9,6 +9,7 @@ import fr.rob.game.event.DomainEventInterface
 import fr.rob.game.instance.MapInstance
 import fr.rob.game.player.session.GameSession
 import fr.rob.game.map.grid.Cell
+import fr.rob.game.map.grid.chunk.ChunkId
 import fr.rob.game.ability.Ability
 import fr.rob.game.ability.AbilityInfo
 import fr.rob.game.behavior.BehaviorInterface
@@ -22,6 +23,7 @@ open class WorldObject(
     var isInWorld = false
     lateinit var mapInstance: MapInstance
     lateinit var position: Position
+    var cachedChunkId: ChunkId? = null
 
     var controlledByGameSession: GameSession? = null
 
@@ -75,14 +77,6 @@ open class WorldObject(
 
     fun getCell(): Cell {
         return mapInstance.getWorldObjectCell(this)
-    }
-
-    fun addIntoInstance(instance: MapInstance, toPosition: Position) {
-        mapInstance = instance
-        position = toPosition
-        isInWorld = true
-
-        mapInstance.addInInstance(this)
     }
 
     fun scheduleRemoveFromInstance() {

--- a/servers/game/src/main/kotlin/fr/rob/game/instance/InstanceManager.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/instance/InstanceManager.kt
@@ -1,21 +1,30 @@
 package fr.rob.game.instance
 
 import fr.rob.game.map.grid.GridBuilder
+import fr.rob.game.map.grid.chunk.ChunkManager
 import fr.rob.game.map.Map
 
 class InstanceManager(private val gridBuilder: GridBuilder) {
 
     private val instances = ArrayList<MapInstance>()
+    private val chunkManagers = mutableMapOf<Int, ChunkManager>()
 
     fun create(id: Int, map: Map): MapInstance {
-        val instance = MapInstance(
-            id,
-            map,
-            gridBuilder.buildGrid(GridBuilder.DEFAULT_CELL_SIZE, map.zoneInfo.width, map.zoneInfo.height),
-        )
+        val grid = gridBuilder.buildGrid(GridBuilder.DEFAULT_CELL_SIZE, map.zoneInfo.width, map.zoneInfo.height)
+        val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
+
+        val instance = MapInstance(id, map, grid)
         instances.add(instance)
+        registerChunkManager(id, chunkManager)
 
         return instance
+    }
+
+    fun getChunkManager(instanceId: Int): ChunkManager =
+        chunkManagers[instanceId] ?: throw RuntimeException("No ChunkManager for instance $instanceId")
+
+    fun registerChunkManager(instanceId: Int, chunkManager: ChunkManager) {
+        chunkManagers[instanceId] = chunkManager
     }
 
     fun retrieve(id: Int): MapInstance {

--- a/servers/game/src/main/kotlin/fr/rob/game/instance/InstanceUpdateService.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/instance/InstanceUpdateService.kt
@@ -1,0 +1,75 @@
+package fr.rob.game.instance
+
+import fr.rob.game.entity.WorldObject
+import fr.rob.game.entity.guid.ObjectGuid
+import fr.rob.game.event.DomainEventDispatcherInterface
+
+class InstanceUpdateService(
+    private val instanceManager: InstanceManager,
+) {
+
+    fun update(instance: MapInstance, deltaTime: Int, eventDispatcher: DomainEventDispatcherInterface) {
+        val chunkManager = instanceManager.getChunkManager(instance.id)
+
+        val newlyDormant = chunkManager.update(deltaTime)
+        for (chunkId in newlyDormant) {
+            chunkManager.despawnChunkEntities(chunkId)
+        }
+
+        updateActiveEntitiesOfType(chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.PLAYER), deltaTime, eventDispatcher)
+        updateScriptableObjects(instance, deltaTime, eventDispatcher)
+        updateActiveEntitiesOfType(chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT), deltaTime, eventDispatcher)
+
+        instance.getDomainEventContainer().forEach { event ->
+            eventDispatcher.dispatch(event)
+        }
+
+        instance.resetDomainEvents()
+
+        instance.consumeScheduledRemovals().forEach { worldObject ->
+            if (worldObject.guid.isPlayer()) {
+                chunkManager.onPlayerLeft(worldObject)
+            }
+
+            val chunkId = worldObject.cachedChunkId
+            if (chunkId != null) {
+                chunkManager.unregisterEntity(worldObject, chunkId)
+            }
+
+            instance.grid.removeWorldObject(worldObject)
+        }
+    }
+
+    /**
+     * ScriptedWorldObjects bypass the chunk system — always ticked.
+     */
+    private fun updateScriptableObjects(
+        instance: MapInstance,
+        deltaTime: Int,
+        eventDispatcher: DomainEventDispatcherInterface,
+    ) {
+        instance.grid.getObjectsByType(ObjectGuid.GUID_TYPE.SCRIPTABLE_OBJECT).forEach {
+            it.onUpdate(deltaTime)
+            dispatchWorldObjectEvents(it, eventDispatcher)
+            it.onAfterUpdate()
+        }
+    }
+
+    private fun updateActiveEntitiesOfType(
+        entities: Sequence<WorldObject>,
+        deltaTime: Int,
+        eventDispatcher: DomainEventDispatcherInterface,
+    ) {
+        entities.forEach {
+            it.onUpdate(deltaTime)
+            dispatchWorldObjectEvents(it, eventDispatcher)
+            it.onAfterUpdate()
+        }
+    }
+
+    private fun dispatchWorldObjectEvents(worldObject: WorldObject, eventDispatcher: DomainEventDispatcherInterface) {
+        worldObject.getDomainEventContainer().forEach { event ->
+            eventDispatcher.dispatch(event)
+        }
+    }
+}

--- a/servers/game/src/main/kotlin/fr/rob/game/instance/MapInstance.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/instance/MapInstance.kt
@@ -2,47 +2,33 @@ package fr.rob.game.instance
 
 import fr.rob.game.entity.Position
 import fr.rob.game.entity.WorldObject
-import fr.rob.game.entity.event.AddedIntoWorldEvent
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.event.DomainEventCarrierInterface
 import fr.rob.game.event.DomainEventContainer
-import fr.rob.game.event.DomainEventDispatcherInterface
 import fr.rob.game.event.DomainEventInterface
 import fr.rob.game.map.grid.Cell
 import fr.rob.game.map.grid.Grid
 import fr.rob.game.map.Map
 
 /**
- * We use MapInstance instead of Instance to avoid confusion with the entity
+ * We use MapInstance instead of Instance to avoid confusion with the entity.
+ * MapInstance is a pure data entity — no service dependencies, no business logic.
  */
 class MapInstance(val id: Int, val map: Map, val grid: Grid) : DomainEventCarrierInterface {
     private val objectsToRemove = ArrayList<WorldObject>()
     private val domainEventContainer = DomainEventContainer()
 
-    fun update(deltaTime: Int, eventDispatcher: DomainEventDispatcherInterface) {
-        objectsToRemove.clear()
-
-        updateGameObjectOfType(ObjectGuid.GUID_TYPE.PLAYER, deltaTime, eventDispatcher)
-        updateGameObjectOfType(ObjectGuid.GUID_TYPE.SCRIPTABLE_OBJECT, deltaTime, eventDispatcher)
-        updateGameObjectOfType(ObjectGuid.GUID_TYPE.GAME_OBJECT, deltaTime, eventDispatcher)
-
-        getDomainEventContainer().forEach { event ->
-            eventDispatcher.dispatch(event)
-        }
-
-        domainEventContainer.resetContainer()
-
-        objectsToRemove.forEach { worldObject -> grid.removeWorldObject(worldObject) }
-    }
-
-    fun addInInstance(worldObject: WorldObject): Cell {
-        pushEvent(AddedIntoWorldEvent(worldObject))
-
-        return grid.addWorldObject(worldObject)
-    }
-
     fun scheduleRemoveFromInstance(worldObject: WorldObject) {
         objectsToRemove.add(worldObject)
+    }
+
+    /**
+     * Returns all objects scheduled for removal and clears the internal list.
+     */
+    fun consumeScheduledRemovals(): List<WorldObject> {
+        val removals = ArrayList(objectsToRemove)
+        objectsToRemove.clear()
+        return removals
     }
 
     fun findObjectsInsideRadius(origin: Position, radius: Float): List<WorldObject> = grid.findObjectsInsideRadius(origin, radius)
@@ -52,22 +38,8 @@ class MapInstance(val id: Int, val map: Map, val grid: Grid) : DomainEventCarrie
         return grid.getCellFromWorldPosition(worldObject.position)
     }
 
-    private fun updateGameObjectOfType(
-        type: ObjectGuid.GUID_TYPE,
-        deltaTime: Int,
-        eventDispatcher: DomainEventDispatcherInterface,
-    ) {
-        grid.getObjectsByType(type).forEach {
-            it.onUpdate(deltaTime)
-            handleGameObjectEvents(it, eventDispatcher)
-            it.onAfterUpdate()
-        }
-    }
-
-    private fun handleGameObjectEvents(worldObject: WorldObject, eventDispatcher: DomainEventDispatcherInterface) {
-        worldObject.getDomainEventContainer().forEach { event ->
-            eventDispatcher.dispatch(event)
-        }
+    fun resetDomainEvents() {
+        domainEventContainer.resetContainer()
     }
 
     override fun pushEvent(event: DomainEventInterface) {

--- a/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkId.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkId.kt
@@ -1,0 +1,3 @@
+package fr.rob.game.map.grid.chunk
+
+data class ChunkId(val x: Int, val y: Int)

--- a/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkManager.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkManager.kt
@@ -39,7 +39,7 @@ class ChunkManager(
     }
 
     fun onPlayerLeft(player: WorldObject) {
-        val oldChunkId = getChunkIdForPosition(player.position)
+        val oldChunkId = player.cachedChunkId ?: return
         val nearbyChunks = getNeighborChunkIds(oldChunkId)
 
         for (chunk in nearbyChunks) {

--- a/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkManager.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkManager.kt
@@ -1,0 +1,183 @@
+package fr.rob.game.map.grid.chunk
+
+import fr.rob.game.entity.WorldObject
+import fr.rob.game.entity.guid.ObjectGuid
+import fr.rob.game.map.grid.Grid
+
+class ChunkManager(
+    private val grid: Grid,
+    private val chunkSize: Int,
+    private val shutdownDurationMs: Int = DEFAULT_SHUTDOWN_DURATION_MS,
+) {
+    private val chunkStates = mutableMapOf<ChunkId, ChunkState>()
+    private val playerCountPerChunk = mutableMapOf<ChunkId, Int>()
+
+    private val entitiesByChunk = mutableMapOf<ChunkId, Array<LinkedHashSet<WorldObject>>>()
+
+    fun getChunkIdForPosition(position: fr.rob.game.entity.Position): ChunkId {
+        val cell = grid.getCellFromWorldPosition(position)
+        return ChunkId(cell.x / chunkSize, cell.y / chunkSize)
+    }
+
+    fun registerEntity(entity: WorldObject, chunkId: ChunkId) {
+        val typeSets = getOrCreateEntitySets(chunkId)
+        typeSets[entity.guid.getType().value].add(entity)
+    }
+
+    fun unregisterEntity(entity: WorldObject, chunkId: ChunkId) {
+        entitiesByChunk[chunkId]?.get(entity.guid.getType().value)?.remove(entity)
+    }
+
+    fun onPlayerEntered(player: WorldObject) {
+        val newChunkId = getChunkIdForPosition(player.position)
+        val nearbyChunks = getNeighborChunkIds(newChunkId)
+
+        for (chunk in nearbyChunks) {
+            incrementPlayerCount(chunk)
+            activateChunk(chunk)
+        }
+    }
+
+    fun onPlayerLeft(player: WorldObject) {
+        val oldChunkId = getChunkIdForPosition(player.position)
+        val nearbyChunks = getNeighborChunkIds(oldChunkId)
+
+        for (chunk in nearbyChunks) {
+            decrementPlayerCount(chunk)
+        }
+    }
+
+    fun onPlayerChunkChanged(oldChunkId: ChunkId, newChunkId: ChunkId) {
+        val oldNearby = getNeighborChunkIds(oldChunkId)
+        val newNearby = getNeighborChunkIds(newChunkId)
+
+        val chunksLost = oldNearby - newNearby.toSet()
+        val chunksGained = newNearby - oldNearby.toSet()
+
+        for (chunk in chunksLost) {
+            decrementPlayerCount(chunk)
+        }
+
+        for (chunk in chunksGained) {
+            incrementPlayerCount(chunk)
+            activateChunk(chunk)
+        }
+    }
+
+    /**
+     * Ticks shutdown timers. Returns chunks that transitioned to Dormant.
+     */
+    fun update(deltaTime: Int): List<ChunkId> {
+        val newlyDormant = mutableListOf<ChunkId>()
+
+        val iterator = chunkStates.iterator()
+        while (iterator.hasNext()) {
+            val (chunkId, state) = iterator.next()
+
+            if (state is ChunkState.ShuttingDown) {
+                state.remainingMs -= deltaTime
+                if (state.remainingMs <= 0) {
+                    iterator.remove()
+                    newlyDormant.add(chunkId)
+                }
+            }
+        }
+
+        return newlyDormant
+    }
+
+    fun despawnChunkEntities(chunkId: ChunkId): List<WorldObject> {
+        val despawned = mutableListOf<WorldObject>()
+        val typeSets = entitiesByChunk[chunkId] ?: return despawned
+
+        for (typeIndex in typeSets.indices) {
+            if (typeIndex == ObjectGuid.GUID_TYPE.PLAYER.value) continue
+
+            val entities = typeSets[typeIndex]
+            for (entity in entities) {
+                grid.removeWorldObject(entity)
+                entity.isInWorld = false
+                despawned.add(entity)
+            }
+            entities.clear()
+        }
+
+        return despawned
+    }
+
+    fun getActiveEntitiesByType(type: ObjectGuid.GUID_TYPE): Sequence<WorldObject> = sequence {
+        for ((chunkId, typeSets) in entitiesByChunk) {
+            if (!isChunkActive(chunkId)) continue
+            yieldAll(typeSets[type.value])
+        }
+    }
+
+    fun getChunkState(chunkId: ChunkId): ChunkState =
+        chunkStates[chunkId] ?: ChunkState.Dormant
+
+    fun getPlayerCount(chunkId: ChunkId): Int =
+        playerCountPerChunk[chunkId] ?: 0
+
+    /**
+     * Returns the chunk IDs in a 1-chunk radius around the given chunk
+     * (including the chunk itself). Clamps to valid grid bounds.
+     */
+    fun getNeighborChunkIds(chunkId: ChunkId): List<ChunkId> {
+        val maxChunkX = (grid.width - 1) / chunkSize
+        val maxChunkY = (grid.height - 1) / chunkSize
+        val neighbors = mutableListOf<ChunkId>()
+
+        for (dx in -1..1) {
+            for (dy in -1..1) {
+                val nx = chunkId.x + dx
+                val ny = chunkId.y + dy
+                if (nx in 0..maxChunkX && ny in 0..maxChunkY) {
+                    neighbors.add(ChunkId(nx, ny))
+                }
+            }
+        }
+
+        return neighbors
+    }
+
+    private fun isChunkActive(chunkId: ChunkId): Boolean {
+        val state = chunkStates[chunkId] ?: return false
+        return state is ChunkState.Active || state is ChunkState.ShuttingDown
+    }
+
+    private fun activateChunk(chunkId: ChunkId) {
+        chunkStates[chunkId] = ChunkState.Active
+    }
+
+    private fun incrementPlayerCount(chunkId: ChunkId) {
+        playerCountPerChunk[chunkId] = (playerCountPerChunk[chunkId] ?: 0) + 1
+    }
+
+    private fun decrementPlayerCount(chunkId: ChunkId) {
+        val count = (playerCountPerChunk[chunkId] ?: 0) - 1
+
+        if (count <= 0) {
+            playerCountPerChunk.remove(chunkId)
+            startShutdown(chunkId)
+        } else {
+            playerCountPerChunk[chunkId] = count
+        }
+    }
+
+    private fun startShutdown(chunkId: ChunkId) {
+        val currentState = chunkStates[chunkId]
+        if (currentState is ChunkState.Active) {
+            chunkStates[chunkId] = ChunkState.ShuttingDown(shutdownDurationMs)
+        }
+    }
+
+    private fun getOrCreateEntitySets(chunkId: ChunkId): Array<LinkedHashSet<WorldObject>> =
+        entitiesByChunk.getOrPut(chunkId) {
+            Array(ObjectGuid.GUID_TYPE.values().size) { LinkedHashSet() }
+        }
+
+    companion object {
+        const val DEFAULT_SHUTDOWN_DURATION_MS = 300_000
+        const val DEFAULT_CHUNK_SIZE = 3
+    }
+}

--- a/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkState.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkState.kt
@@ -1,0 +1,7 @@
+package fr.rob.game.map.grid.chunk
+
+sealed class ChunkState {
+    object Active : ChunkState()
+    data class ShuttingDown(var remainingMs: Int) : ChunkState()
+    object Dormant : ChunkState()
+}

--- a/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkTransitionListener.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/map/grid/chunk/ChunkTransitionListener.kt
@@ -1,0 +1,39 @@
+package fr.rob.game.map.grid.chunk
+
+import fr.rob.game.entity.movement.WorldObjectMovedEvent
+import fr.rob.game.event.DomainEventInterface
+import fr.rob.game.event.DomainEventListenerInterface
+import fr.rob.game.instance.InstanceManager
+
+class ChunkTransitionListener(
+    private val instanceManager: InstanceManager,
+) : DomainEventListenerInterface {
+
+    override fun supports(event: DomainEventInterface): Boolean = event is WorldObjectMovedEvent
+
+    override fun invoke(event: DomainEventInterface) {
+        event as WorldObjectMovedEvent
+
+        val worldObject = event.worldObject
+        if (!worldObject.isInWorld) return
+
+        val chunkManager = instanceManager.getChunkManager(worldObject.mapInstance.id)
+        val newChunkId = chunkManager.getChunkIdForPosition(worldObject.position)
+        val oldChunkId = worldObject.cachedChunkId
+
+        if (oldChunkId == null) {
+            worldObject.cachedChunkId = newChunkId
+            return
+        }
+
+        if (oldChunkId == newChunkId) return
+
+        chunkManager.unregisterEntity(worldObject, oldChunkId)
+        worldObject.cachedChunkId = newChunkId
+        chunkManager.registerEntity(worldObject, newChunkId)
+
+        if (worldObject.guid.isPlayer()) {
+            chunkManager.onPlayerChunkChanged(oldChunkId, newChunkId)
+        }
+    }
+}

--- a/servers/game/src/main/kotlin/fr/rob/game/player/action/CreatePlayerIntoWorldHandler.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/player/action/CreatePlayerIntoWorldHandler.kt
@@ -38,7 +38,7 @@ class CreatePlayerIntoWorldHandler(
         val worldObject = createMobAroundPosition(ObjectGuid.LowGuid(1u, 1u), Position(10f, 0f, 1f, 0f), command.mapInstance)
         val worldObject2 = createMobAroundPosition(ObjectGuid.LowGuid(1u, 2u), Position(10f, 10f, 1f, 0f), command.mapInstance)
 
-        player.addIntoInstance(command.mapInstance, createPlayerResult.position!!)
+        objectManager.addEntityIntoInstance(player, command.mapInstance, createPlayerResult.position!!)
 
         // @todo Send player info
         player.ownerGameSession.send(PlayerDescriptionMessage(player.guid, player.name))

--- a/servers/game/src/main/kotlin/fr/rob/game/spell/effect/SummonInstantDamageAoeEffect.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/spell/effect/SummonInstantDamageAoeEffect.kt
@@ -2,6 +2,7 @@ package fr.rob.game.spell.effect
 
 import fr.rob.game.entity.ScriptedWorldObject
 import fr.rob.game.entity.WorldObject
+import fr.rob.game.entity.event.AddedIntoWorldEvent
 import fr.rob.game.entity.guid.ObjectGuidGenerator
 import fr.rob.game.script.InstantDamageAoeScript
 import fr.rob.game.spell.Spell
@@ -10,6 +11,11 @@ import fr.rob.game.spell.SpellEffectSummary
 import fr.rob.game.spell.SpellEffectTypeEnum
 import fr.rob.game.spell.SpellInfo
 
+/**
+ * @deprecated The spell system is deprecated; use the ability system instead.
+ * This effect bypasses [ObjectManager.addEntityIntoInstance] because DI is not
+ * wired through the spell factory chain. Chunk registration is skipped.
+ */
 class SummonInstantDamageAoeEffect(
     private val spellEffectInfo: SummonInstantDamageAoeEffectInfo,
     private val spellInfo: SpellInfo,
@@ -23,7 +29,14 @@ class SummonInstantDamageAoeEffect(
         )
 
         area.addScript(InstantDamageAoeScript(area, caster, spellEffectInfo.damageValue, spellEffectInfo.radius, spellEffectInfo.frequencyMs, spellEffectInfo.durationMs))
-        area.addIntoInstance(caster.mapInstance, caster.position)
+
+        // Inline placement — deprecated spell system cannot use ObjectManager (no DI path).
+        // Chunk registration is intentionally skipped; ScriptedWorldObjects use the classic loop.
+        area.mapInstance = caster.mapInstance
+        area.position = caster.position
+        area.isInWorld = true
+        caster.mapInstance.pushEvent(AddedIntoWorldEvent(area))
+        caster.mapInstance.grid.addWorldObject(area)
     }
 
     class SummonInstantDamageAoeEffectInfo(val damageValue: Int, val radius: Float, val frequencyMs: Int, val durationMs: Int) :

--- a/servers/game/src/main/kotlin/fr/rob/game/world/World.kt
+++ b/servers/game/src/main/kotlin/fr/rob/game/world/World.kt
@@ -8,11 +8,14 @@ import fr.rob.game.entity.notifier.Scheduler
 import fr.rob.game.entity.notifier.WorldObjectUpdatedNotifier
 import fr.rob.game.event.ListEventDispatcher
 import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
+import fr.rob.game.map.grid.chunk.ChunkTransitionListener
 import fr.rob.game.world.packet.WorldPacketQueue
 import fr.rob.game.ability.event.NotifyAbilityFailedListener
 
 class World(
     private val instanceManager: InstanceManager,
+    private val instanceUpdateService: InstanceUpdateService,
     private val worldPacketQueue: WorldPacketQueue,
     private val delayedUpdateQueue: DelayedUpdateQueue,
 ) {
@@ -27,6 +30,7 @@ class World(
         eventDispatcher.attachListener(GetNearbyObjectListener())
         eventDispatcher.attachListener(ObjectSheetUpdatedListener())
         eventDispatcher.attachListener(NotifyAbilityFailedListener())
+        eventDispatcher.attachListener(ChunkTransitionListener(instanceManager))
     }
 
     fun update(deltaTime: Int) {
@@ -35,6 +39,6 @@ class World(
 
         worldPacketQueue.dequeue()
         delayedUpdateQueue.dequeue(deltaTime)
-        instanceManager.getAllInstances().forEach { instance -> instance.update(deltaTime, eventDispatcher) }
+        instanceManager.getAllInstances().forEach { instance -> instanceUpdateService.update(instance, deltaTime, eventDispatcher) }
     }
 }

--- a/servers/game/src/test/kotlin/fr/rob/game/test/feature/specs/PlayerCheatTeleport.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/feature/specs/PlayerCheatTeleport.kt
@@ -6,6 +6,7 @@ import fr.rob.game.player.message.MovementHeartbeatMessage
 import fr.rob.game.entity.Position
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
 import fr.rob.game.player.session.GameSession
 import fr.rob.game.map.Map
 import fr.rob.game.map.MapInfo
@@ -32,7 +33,7 @@ class PlayerCheatTeleport : DatabaseTestApplication() {
 
         val instanceManager = get<InstanceManager>()
         val worldPacketQueue = get<WorldPacketQueue>()
-        val world = World(instanceManager, worldPacketQueue, get<DelayedUpdateQueue>())
+        val world = World(instanceManager, InstanceUpdateService(instanceManager), worldPacketQueue, get<DelayedUpdateQueue>())
 
         instanceManager.create(
             PlayerJoiningWorld.DEFAULT_TEST_INSTANCE_ID,

--- a/servers/game/src/test/kotlin/fr/rob/game/test/feature/specs/PlayerJoiningWorld.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/feature/specs/PlayerJoiningWorld.kt
@@ -7,6 +7,7 @@ import fr.rob.game.entity.ObjectManager
 import fr.rob.game.entity.Position
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
 import fr.rob.game.player.session.GameSession
 import fr.rob.game.map.Map
 import fr.rob.game.map.MapInfo
@@ -34,7 +35,7 @@ class PlayerJoiningWorld : DatabaseTestApplication() {
         val instanceManager = get<InstanceManager>()
         val worldPacketQueue = get<WorldPacketQueue>()
         val objectManager = get<ObjectManager>()
-        val world = World(instanceManager, worldPacketQueue, get<DelayedUpdateQueue>())
+        val world = World(instanceManager, InstanceUpdateService(instanceManager), worldPacketQueue, get<DelayedUpdateQueue>())
 
         val instance = instanceManager.create(
             DEFAULT_TEST_INSTANCE_ID,

--- a/servers/game/src/test/kotlin/fr/rob/game/test/feature/specs/PlayerMoving.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/feature/specs/PlayerMoving.kt
@@ -6,6 +6,7 @@ import fr.raven.proto.message.game.setup.LogIntoWorldProto
 import fr.rob.game.player.message.MovementHeartbeatMessage
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
 import fr.rob.game.player.session.GameSession
 import fr.rob.game.map.Map
 import fr.rob.game.map.MapInfo
@@ -29,7 +30,7 @@ class PlayerMoving : DatabaseTestApplication() {
 
         val instanceManager = get<InstanceManager>()
         val worldPacketQueue = get<WorldPacketQueue>()
-        val world = World(instanceManager, worldPacketQueue, get<DelayedUpdateQueue>())
+        val world = World(instanceManager, InstanceUpdateService(instanceManager), worldPacketQueue, get<DelayedUpdateQueue>())
 
         instanceManager.create(
             PlayerJoiningWorld.DEFAULT_TEST_INSTANCE_ID,

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/ability/AbilityEffectsTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/ability/AbilityEffectsTest.kt
@@ -171,7 +171,7 @@ class AbilityEffectsTest {
         )
         unitToCreate.addComponent(HealthComponent(100))
         unitToCreate.addBehavior(ObjectSheetBehavior(riggedDiceEngine))
-        unitToCreate.addIntoInstance(instance, position)
+        WorldBuilder.addIntoInstance(unitToCreate, instance, position)
 
         return unitToCreate
     }

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/ability/AbilityEffectsTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/ability/AbilityEffectsTest.kt
@@ -33,7 +33,8 @@ class AbilityEffectsTest {
     private lateinit var caster: WorldUnit
     private lateinit var target: WorldUnit
     private val riggedDiceEngine = RiggedDiceEngine()
-    private val instance = WorldBuilder.buildBasicWorld()
+    private val worldBuilder = WorldBuilder()
+    private val instance = worldBuilder.buildBasicWorld()
     private val guidGenerator = ObjectGuidGenerator()
     private var entryGuid: UInt = 1u
 
@@ -171,7 +172,7 @@ class AbilityEffectsTest {
         )
         unitToCreate.addComponent(HealthComponent(100))
         unitToCreate.addBehavior(ObjectSheetBehavior(riggedDiceEngine))
-        WorldBuilder.addIntoInstance(unitToCreate, instance, position)
+        worldBuilder.addIntoInstance(unitToCreate, instance, position)
 
         return unitToCreate
     }

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/instance/InstanceUpdateServiceTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/instance/InstanceUpdateServiceTest.kt
@@ -1,0 +1,407 @@
+package fr.rob.game.test.unit.domain.game.instance
+
+import fr.rob.game.behavior.BehaviorInterface
+import fr.rob.game.entity.Position
+import fr.rob.game.entity.ScriptedWorldObject
+import fr.rob.game.entity.WorldObject
+import fr.rob.game.entity.guid.ObjectGuid
+import fr.rob.game.entity.guid.ObjectGuidGenerator
+import fr.rob.game.event.ListEventDispatcher
+import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
+import fr.rob.game.instance.MapInstance
+import fr.rob.game.map.grid.GridBuilder
+import fr.rob.game.map.grid.GridConstraintChecker
+import fr.rob.game.map.grid.chunk.ChunkId
+import fr.rob.game.map.grid.chunk.ChunkManager
+import fr.rob.game.map.grid.chunk.ChunkState
+import fr.rob.game.map.grid.chunk.ChunkTransitionListener
+import fr.rob.game.test.unit.tools.DummyWorldObjectBuilder
+import fr.rob.game.test.unit.tools.VoidEventDispatcher
+import fr.rob.game.test.unit.tools.WorldBuilder
+import fr.rob.game.test.unit.domain.game.world.grid.chunk.ChunkManagerTest.Companion.createInstanceWithChunkManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Integration tests for [InstanceUpdateService] — verifies the full tick
+ * orchestration: chunk-aware entity updates, scriptable object updates,
+ * despawn on shutdown expiry, and scheduled removal processing.
+ *
+ * Uses the same grid layout as ChunkManagerTest (10x10 cells, cellSize=10, zone 100x100).
+ */
+class InstanceUpdateServiceTest {
+
+    private val instanceManager = createTestInstanceManager()
+    private val service = InstanceUpdateService(instanceManager)
+    private val eventDispatcher = VoidEventDispatcher()
+    private val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
+    private val guidGenerator = ObjectGuidGenerator()
+
+    companion object {
+        /** Cell (0,0) → chunk (0,0) */
+        fun posInChunk00() = Position(-45f, -45f, 0f, 0f)
+
+        /** Cell (1,0) → chunk (0,0) — same chunk, different cell */
+        fun posInChunk00Alt() = Position(-35f, -45f, 0f, 0f)
+
+        /** Cell (9,9) → chunk (3,3) — far away from chunk (0,0) */
+        fun posInChunk33() = Position(45f, 45f, 0f, 0f)
+
+        /** Cell (3,0) → chunk (1,0) */
+        fun posInChunk10() = Position(-15f, -45f, 0f, 0f)
+
+        private fun createTestInstanceManager(): InstanceManager {
+            return InstanceManager(GridBuilder(GridConstraintChecker()))
+        }
+    }
+
+    /**
+     * Builds an instance using WorldBuilder's basic world and registers its
+     * chunk manager in the test InstanceManager.
+     */
+    private fun buildTestInstance(): MapInstance {
+        val instance = WorldBuilder.buildBasicWorld()
+        val grid = instance.grid
+        val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
+        WorldBuilder.registerChunkManager(instance.id, chunkManager)
+        instanceManager.registerChunkManager(instance.id, chunkManager)
+        return instance
+    }
+
+    private fun buildCustomInstance(
+        grid: fr.rob.game.map.grid.Grid,
+        cm: ChunkManager,
+    ): MapInstance {
+        val instance = createInstanceWithChunkManager(grid, cm)
+        instanceManager.registerChunkManager(instance.id, cm)
+        return instance
+    }
+
+    // ──────────────────────────────────────────────
+    // Chunk-aware entity ticking
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class ChunkAwareTicking {
+        @Test
+        fun `entities in active chunks are ticked`() {
+            val instance = buildTestInstance()
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            val spy = TickCountBehavior()
+            unit.addBehavior(spy)
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            service.update(instance, 20, eventDispatcher)
+
+            assertEquals(1, spy.tickCount)
+        }
+
+        @Test
+        fun `entities in dormant chunks are NOT ticked`() {
+            val instance = buildTestInstance()
+
+            // No player → all chunks dormant
+            val unit = objectBuilder.createUnit()
+            val spy = TickCountBehavior()
+            unit.addBehavior(spy)
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00())
+
+            service.update(instance, 20, eventDispatcher)
+
+            assertEquals(0, spy.tickCount)
+        }
+
+        @Test
+        fun `entities in shutting-down chunks are still ticked`() {
+            val instance = buildTestInstance()
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            val spy = TickCountBehavior()
+            unit.addBehavior(spy)
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            val cm = instanceManager.getChunkManager(instance.id)
+            cm.onPlayerLeft(player)
+
+            service.update(instance, 20, eventDispatcher)
+
+            assertEquals(1, spy.tickCount)
+        }
+
+        @Test
+        fun `players in active chunks are ticked`() {
+            val instance = buildTestInstance()
+            val player = objectBuilder.createPlayer()
+            val spy = TickCountBehavior()
+            player.addBehavior(spy)
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            service.update(instance, 20, eventDispatcher)
+
+            assertEquals(1, spy.tickCount)
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ScriptedWorldObjects always ticked
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class ScriptedWorldObjectTicking {
+        @Test
+        fun `scripted world objects are ticked even with all chunks dormant`() {
+            val instance = buildTestInstance()
+
+            val scripted = createScriptedWorldObject()
+            val spy = TickCountBehavior()
+            scripted.addBehavior(spy)
+            WorldBuilder.addIntoInstance(scripted, instance, posInChunk00())
+
+            // No player → all chunks dormant
+            service.update(instance, 20, eventDispatcher)
+
+            assertEquals(1, spy.tickCount)
+        }
+
+        @Test
+        fun `scripted world objects are ticked alongside active chunk entities`() {
+            val instance = buildTestInstance()
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val scripted = createScriptedWorldObject()
+            val spyScripted = TickCountBehavior()
+            scripted.addBehavior(spyScripted)
+            WorldBuilder.addIntoInstance(scripted, instance, posInChunk33()) // far away chunk, dormant
+
+            val unit = objectBuilder.createUnit()
+            val spyUnit = TickCountBehavior()
+            unit.addBehavior(spyUnit)
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            service.update(instance, 20, eventDispatcher)
+
+            assertEquals(1, spyScripted.tickCount, "ScriptedWorldObject should be ticked regardless of chunk state")
+            assertEquals(1, spyUnit.tickCount, "GAME_OBJECT in active chunk should be ticked")
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Despawn on shutdown expiry
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class DespawnOnShutdownExpiry {
+        @Test
+        fun `entities are despawned when shutdown timer expires during update`() {
+            val shutdownMs = 100
+            val grid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
+            val cm = ChunkManager(grid, 3, shutdownMs)
+            val instance = buildCustomInstance(grid, cm)
+
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            cm.onPlayerLeft(player)
+            assertTrue(unit.isInWorld)
+
+            // Tick enough to expire the shutdown
+            service.update(instance, 100, eventDispatcher)
+
+            val chunkId = cm.getChunkIdForPosition(unit.position)
+            assertEquals(ChunkState.Dormant, cm.getChunkState(chunkId))
+            assertFalse(unit.isInWorld)
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Scheduled removal processing
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class ScheduledRemovalProcessing {
+        @Test
+        fun `scheduled removals are processed and entities removed from grid`() {
+            val instance = buildTestInstance()
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            unit.scheduleRemoveFromInstance()
+
+            service.update(instance, 20, eventDispatcher)
+
+            val found = instance.grid.findObjectByGuid(unit.guid)
+            assertEquals(null, found)
+        }
+
+        @Test
+        fun `player removal triggers onPlayerLeft on chunk manager`() {
+            val instance = buildTestInstance()
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val cm = instanceManager.getChunkManager(instance.id)
+            val chunkId = ChunkId(0, 0)
+            assertEquals(1, cm.getPlayerCount(chunkId))
+
+            player.scheduleRemoveFromInstance()
+            service.update(instance, 20, eventDispatcher)
+
+            assertEquals(0, cm.getPlayerCount(chunkId))
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Full lifecycle
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class FullLifecycle {
+        @Test
+        fun `multiple ticks with player enter, entity tick, player leave, shutdown, and despawn`() {
+            val shutdownMs = 200
+            val grid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
+            val cm = ChunkManager(grid, 3, shutdownMs)
+            val instance = buildCustomInstance(grid, cm)
+
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            val spy = TickCountBehavior()
+            unit.addBehavior(spy)
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            // Tick 1: everything active
+            service.update(instance, 50, eventDispatcher)
+            assertEquals(1, spy.tickCount)
+            assertTrue(unit.isInWorld)
+
+            // Player leaves → shutdown timer starts at 200ms
+            cm.onPlayerLeft(player)
+
+            // Tick 2: 200 → 150ms, still shutting down, entities ticked
+            service.update(instance, 50, eventDispatcher)
+            assertEquals(2, spy.tickCount)
+
+            // Tick 3: 150 → 100ms
+            service.update(instance, 50, eventDispatcher)
+            assertEquals(3, spy.tickCount)
+
+            // Tick 4: 100 → 50ms
+            service.update(instance, 50, eventDispatcher)
+            assertEquals(4, spy.tickCount)
+            assertTrue(unit.isInWorld)
+
+            // Tick 5: 50 → 0ms, shutdown expires → chunk becomes dormant → entities despawned
+            service.update(instance, 50, eventDispatcher)
+            assertFalse(unit.isInWorld)
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Chunk transition on movement
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class ChunkTransitionOnMovement {
+
+        private fun buildEventDispatcherWithChunkTransition(): ListEventDispatcher {
+            val dispatcher = ListEventDispatcher()
+            dispatcher.attachListener(ChunkTransitionListener(instanceManager))
+            return dispatcher
+        }
+
+        @Test
+        fun `player moving to another chunk is transferred from old chunk entity set to new chunk entity set`() {
+            val instance = buildTestInstance()
+            val cm = instanceManager.getChunkManager(instance.id)
+            val dispatcher = buildEventDispatcherWithChunkTransition()
+
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            assertEquals(ChunkId(0, 0), player.cachedChunkId)
+
+            player.addBehavior(MoveOnUpdateBehavior(posInChunk33()))
+            service.update(instance, 20, dispatcher)
+
+            assertEquals(ChunkId(3, 3), player.cachedChunkId)
+
+            val playersInNewChunk = cm.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.PLAYER).toList()
+            assertTrue(playersInNewChunk.contains(player))
+            assertEquals(ChunkState.Active, cm.getChunkState(ChunkId(3, 3)))
+        }
+
+        @Test
+        fun `game object moving to another chunk is transferred between chunk entity sets`() {
+            val instance = buildTestInstance()
+            val cm = instanceManager.getChunkManager(instance.id)
+            val dispatcher = buildEventDispatcherWithChunkTransition()
+
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            assertEquals(ChunkId(0, 0), unit.cachedChunkId)
+
+            unit.addBehavior(MoveOnUpdateBehavior(posInChunk10()))
+            service.update(instance, 20, dispatcher)
+
+            assertEquals(ChunkId(1, 0), unit.cachedChunkId)
+
+            val activeUnits = cm.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT).toList()
+            assertTrue(activeUnits.contains(unit))
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────
+
+    private fun createScriptedWorldObject(): ScriptedWorldObject {
+        val guid = guidGenerator.createForScriptableObject(
+            objectBuilder.createUnit(),
+            1,
+        )
+        return ScriptedWorldObject(guid)
+    }
+
+    private class TickCountBehavior : BehaviorInterface {
+        var tickCount = 0
+
+        override fun update(worldObject: WorldObject, deltaTime: Int) {
+            tickCount++
+        }
+
+        override fun canApplyTo(worldObject: WorldObject): Boolean = true
+    }
+
+    private class MoveOnUpdateBehavior(private val target: Position) : BehaviorInterface {
+        private var moved = false
+
+        override fun update(worldObject: WorldObject, deltaTime: Int) {
+            if (!moved) {
+                worldObject.setPosition(target.x, target.y, target.z, target.orientation)
+                moved = true
+            }
+        }
+
+        override fun canApplyTo(worldObject: WorldObject): Boolean = true
+    }
+}

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/instance/InstanceUpdateServiceTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/instance/InstanceUpdateServiceTest.kt
@@ -19,7 +19,6 @@ import fr.rob.game.map.grid.chunk.ChunkTransitionListener
 import fr.rob.game.test.unit.tools.DummyWorldObjectBuilder
 import fr.rob.game.test.unit.tools.VoidEventDispatcher
 import fr.rob.game.test.unit.tools.WorldBuilder
-import fr.rob.game.test.unit.domain.game.world.grid.chunk.ChunkManagerTest.Companion.createInstanceWithChunkManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.Test
  */
 class InstanceUpdateServiceTest {
 
+    private val worldBuilder = WorldBuilder()
     private val instanceManager = createTestInstanceManager()
     private val service = InstanceUpdateService(instanceManager)
     private val eventDispatcher = VoidEventDispatcher()
@@ -64,10 +64,8 @@ class InstanceUpdateServiceTest {
      * chunk manager in the test InstanceManager.
      */
     private fun buildTestInstance(): MapInstance {
-        val instance = WorldBuilder.buildBasicWorld()
-        val grid = instance.grid
-        val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
-        WorldBuilder.registerChunkManager(instance.id, chunkManager)
+        val instance = worldBuilder.buildBasicWorld()
+        val chunkManager = worldBuilder.getChunkManager(instance.id)!!
         instanceManager.registerChunkManager(instance.id, chunkManager)
         return instance
     }
@@ -76,7 +74,7 @@ class InstanceUpdateServiceTest {
         grid: fr.rob.game.map.grid.Grid,
         cm: ChunkManager,
     ): MapInstance {
-        val instance = createInstanceWithChunkManager(grid, cm)
+        val instance = worldBuilder.buildInstanceWithChunkManager(grid, cm)
         instanceManager.registerChunkManager(instance.id, cm)
         return instance
     }
@@ -91,12 +89,12 @@ class InstanceUpdateServiceTest {
         fun `entities in active chunks are ticked`() {
             val instance = buildTestInstance()
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
             val spy = TickCountBehavior()
             unit.addBehavior(spy)
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             service.update(instance, 20, eventDispatcher)
 
@@ -111,7 +109,7 @@ class InstanceUpdateServiceTest {
             val unit = objectBuilder.createUnit()
             val spy = TickCountBehavior()
             unit.addBehavior(spy)
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00())
 
             service.update(instance, 20, eventDispatcher)
 
@@ -122,12 +120,12 @@ class InstanceUpdateServiceTest {
         fun `entities in shutting-down chunks are still ticked`() {
             val instance = buildTestInstance()
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
             val spy = TickCountBehavior()
             unit.addBehavior(spy)
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             val cm = instanceManager.getChunkManager(instance.id)
             cm.onPlayerLeft(player)
@@ -143,7 +141,7 @@ class InstanceUpdateServiceTest {
             val player = objectBuilder.createPlayer()
             val spy = TickCountBehavior()
             player.addBehavior(spy)
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             service.update(instance, 20, eventDispatcher)
 
@@ -164,7 +162,7 @@ class InstanceUpdateServiceTest {
             val scripted = createScriptedWorldObject()
             val spy = TickCountBehavior()
             scripted.addBehavior(spy)
-            WorldBuilder.addIntoInstance(scripted, instance, posInChunk00())
+            worldBuilder.addIntoInstance(scripted, instance, posInChunk00())
 
             // No player → all chunks dormant
             service.update(instance, 20, eventDispatcher)
@@ -176,17 +174,17 @@ class InstanceUpdateServiceTest {
         fun `scripted world objects are ticked alongside active chunk entities`() {
             val instance = buildTestInstance()
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val scripted = createScriptedWorldObject()
             val spyScripted = TickCountBehavior()
             scripted.addBehavior(spyScripted)
-            WorldBuilder.addIntoInstance(scripted, instance, posInChunk33()) // far away chunk, dormant
+            worldBuilder.addIntoInstance(scripted, instance, posInChunk33()) // far away chunk, dormant
 
             val unit = objectBuilder.createUnit()
             val spyUnit = TickCountBehavior()
             unit.addBehavior(spyUnit)
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             service.update(instance, 20, eventDispatcher)
 
@@ -209,10 +207,10 @@ class InstanceUpdateServiceTest {
             val instance = buildCustomInstance(grid, cm)
 
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             cm.onPlayerLeft(player)
             assertTrue(unit.isInWorld)
@@ -236,10 +234,10 @@ class InstanceUpdateServiceTest {
         fun `scheduled removals are processed and entities removed from grid`() {
             val instance = buildTestInstance()
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             unit.scheduleRemoveFromInstance()
 
@@ -253,7 +251,7 @@ class InstanceUpdateServiceTest {
         fun `player removal triggers onPlayerLeft on chunk manager`() {
             val instance = buildTestInstance()
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val cm = instanceManager.getChunkManager(instance.id)
             val chunkId = ChunkId(0, 0)
@@ -280,12 +278,12 @@ class InstanceUpdateServiceTest {
             val instance = buildCustomInstance(grid, cm)
 
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
             val spy = TickCountBehavior()
             unit.addBehavior(spy)
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             // Tick 1: everything active
             service.update(instance, 50, eventDispatcher)
@@ -334,7 +332,7 @@ class InstanceUpdateServiceTest {
             val dispatcher = buildEventDispatcherWithChunkTransition()
 
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
             assertEquals(ChunkId(0, 0), player.cachedChunkId)
 
             player.addBehavior(MoveOnUpdateBehavior(posInChunk33()))
@@ -354,10 +352,10 @@ class InstanceUpdateServiceTest {
             val dispatcher = buildEventDispatcherWithChunkTransition()
 
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
             assertEquals(ChunkId(0, 0), unit.cachedChunkId)
 
             unit.addBehavior(MoveOnUpdateBehavior(posInChunk10()))

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/ObjectManagerTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/ObjectManagerTest.kt
@@ -14,7 +14,6 @@ import fr.rob.game.map.grid.chunk.ChunkManager
 import fr.rob.game.map.Map
 import fr.rob.game.map.MapInfo
 import fr.rob.game.map.ZoneInfo
-import fr.rob.game.test.unit.tools.WorldBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -41,7 +40,6 @@ class ObjectManagerTest {
         val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
         val instance = MapInstance(13, map, grid)
         testInstanceManager.registerChunkManager(instance.id, chunkManager)
-        WorldBuilder.registerChunkManager(instance.id, chunkManager)
         val position = Position(10f, 0f, 15f, 0f)
         val lowGuid = ObjectGuid.LowGuid(1u, 1u)
 
@@ -69,7 +67,6 @@ class ObjectManagerTest {
         val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
         val instance = MapInstance(13, map, grid)
         testInstanceManager.registerChunkManager(instance.id, chunkManager)
-        WorldBuilder.registerChunkManager(instance.id, chunkManager)
         val lowGuid = ObjectGuid.LowGuid(1u, 1u)
 
         // Act & Assert

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/ObjectManagerTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/ObjectManagerTest.kt
@@ -5,13 +5,16 @@ import fr.rob.game.entity.Position
 import fr.rob.game.entity.OutOfBoundsException
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.entity.guid.ObjectGuidGenerator
+import fr.rob.game.instance.InstanceManager
 import fr.rob.game.instance.MapInstance
 import fr.rob.game.map.grid.Grid
 import fr.rob.game.map.grid.GridBuilder
 import fr.rob.game.map.grid.GridConstraintChecker
+import fr.rob.game.map.grid.chunk.ChunkManager
 import fr.rob.game.map.Map
 import fr.rob.game.map.MapInfo
 import fr.rob.game.map.ZoneInfo
+import fr.rob.game.test.unit.tools.WorldBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -24,6 +27,8 @@ import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ObjectManagerTest {
+    private val testInstanceManager = InstanceManager(GridBuilder(GridConstraintChecker()))
+
     @Test
     fun `As OM, I should successfully create an object in a specific instance`() {
         // Arrange
@@ -33,7 +38,10 @@ class ObjectManagerTest {
         val map = Map(1, 1, mapInfo, zoneInfo)
         val gridBuilder = GridBuilder(GridConstraintChecker())
         val grid = gridBuilder.buildGrid(10, zoneInfo.width, zoneInfo.height)
+        val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
         val instance = MapInstance(13, map, grid)
+        testInstanceManager.registerChunkManager(instance.id, chunkManager)
+        WorldBuilder.registerChunkManager(instance.id, chunkManager)
         val position = Position(10f, 0f, 15f, 0f)
         val lowGuid = ObjectGuid.LowGuid(1u, 1u)
 
@@ -58,7 +66,10 @@ class ObjectManagerTest {
         val mapInfo = MapInfo("A testing map", 200, 200)
         val map = Map(1, 1, mapInfo, zoneInfo)
         val grid = Grid(100, 100, 10, emptyArray())
+        val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
         val instance = MapInstance(13, map, grid)
+        testInstanceManager.registerChunkManager(instance.id, chunkManager)
+        WorldBuilder.registerChunkManager(instance.id, chunkManager)
         val lowGuid = ObjectGuid.LowGuid(1u, 1u)
 
         // Act & Assert
@@ -88,5 +99,5 @@ class ObjectManagerTest {
         )
     )
 
-    private fun getObjectManager(): ObjectManager = ObjectManager(ObjectGuidGenerator())
+    private fun getObjectManager(): ObjectManager = ObjectManager(ObjectGuidGenerator(), testInstanceManager)
 }

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/entity/player/PlayerFactoryTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/entity/player/PlayerFactoryTest.kt
@@ -6,14 +6,8 @@ import fr.rob.game.character.CheckCharacterExistInterface
 import fr.rob.game.character.FetchCharacterInterface
 import fr.rob.game.entity.Position
 import fr.rob.game.entity.guid.ObjectGuidGenerator
-import fr.rob.game.instance.MapInstance
 import fr.rob.game.player.PlayerFactory
 import fr.rob.game.player.session.GameSession
-import fr.rob.game.map.grid.GridBuilder
-import fr.rob.game.map.grid.GridConstraintChecker
-import fr.rob.game.map.Map
-import fr.rob.game.map.MapInfo
-import fr.rob.game.map.ZoneInfo
 import fr.rob.game.test.unit.sandbox.network.session.NullMessageSender
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -62,19 +56,6 @@ class PlayerFactoryTest {
         // Assert
         assertFalse(result.isSuccess)
         assertNull(result.player)
-    }
-
-    private fun getMapInstance(): MapInstance {
-        val gridBuilder = GridBuilder(GridConstraintChecker())
-        val cellSize = 1
-        val width = 20
-        val height = 20
-
-        return MapInstance(
-            1,
-            Map(1, 2, MapInfo("Map info", width, width), ZoneInfo("Zone info", width, height, 0f, 0f)),
-            gridBuilder.buildGrid(cellSize, width, height),
-        )
     }
 
     class CharacterFoundForUser : CheckCharacterExistInterface {

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/GridTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/GridTest.kt
@@ -52,21 +52,21 @@ class GridTest {
         // Create objects with ComponentA
         val objectWithA1 = objectBuilder.createUnit()
         objectWithA1.addComponent(TestComponentA())
-        objectWithA1.addIntoInstance(instance, Position(5f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithA1, instance, Position(5f, 5f, 0f, 0f))
 
         val objectWithA2 = objectBuilder.createUnit()
         objectWithA2.addComponent(TestComponentA())
-        objectWithA2.addIntoInstance(instance, Position(8f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithA2, instance, Position(8f, 5f, 0f, 0f))
 
         // Create objects with ComponentB (not A)
         val objectWithB = objectBuilder.createUnit()
         objectWithB.addComponent(TestComponentB())
-        objectWithB.addIntoInstance(instance, Position(6f, 6f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithB, instance, Position(6f, 6f, 0f, 0f))
 
         // Create object with ComponentA but outside radius
         val objectWithAOutside = objectBuilder.createUnit()
         objectWithAOutside.addComponent(TestComponentA())
-        objectWithAOutside.addIntoInstance(instance, Position(50f, 50f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithAOutside, instance, Position(50f, 50f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 5f
@@ -90,7 +90,7 @@ class GridTest {
 
         val objectWithB = objectBuilder.createUnit()
         objectWithB.addComponent(TestComponentB())
-        objectWithB.addIntoInstance(instance, Position(5f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithB, instance, Position(5f, 5f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -110,7 +110,7 @@ class GridTest {
 
         val objectWithA = objectBuilder.createUnit()
         objectWithA.addComponent(TestComponentA())
-        objectWithA.addIntoInstance(instance, Position(50f, 50f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithA, instance, Position(50f, 50f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 5f
@@ -132,23 +132,23 @@ class GridTest {
         val objectWithAB = objectBuilder.createUnit()
         objectWithAB.addComponent(TestComponentA())
         objectWithAB.addComponent(TestComponentB())
-        objectWithAB.addIntoInstance(instance, Position(5f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithAB, instance, Position(5f, 5f, 0f, 0f))
 
         // Object with only ComponentA
         val objectWithOnlyA = objectBuilder.createUnit()
         objectWithOnlyA.addComponent(TestComponentA())
-        objectWithOnlyA.addIntoInstance(instance, Position(6f, 6f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithOnlyA, instance, Position(6f, 6f, 0f, 0f))
 
         // Object with only ComponentB
         val objectWithOnlyB = objectBuilder.createUnit()
         objectWithOnlyB.addComponent(TestComponentB())
-        objectWithOnlyB.addIntoInstance(instance, Position(7f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithOnlyB, instance, Position(7f, 5f, 0f, 0f))
 
         // Object with both components but outside radius
         val objectWithABOutside = objectBuilder.createUnit()
         objectWithABOutside.addComponent(TestComponentA())
         objectWithABOutside.addComponent(TestComponentB())
-        objectWithABOutside.addIntoInstance(instance, Position(50f, 50f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithABOutside, instance, Position(50f, 50f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 5f
@@ -177,7 +177,7 @@ class GridTest {
 
         val obj = objectBuilder.createUnit()
         obj.addComponent(TestComponentA())
-        obj.addIntoInstance(instance, Position(5f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(obj, instance, Position(5f, 5f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -197,11 +197,11 @@ class GridTest {
 
         val objectWithA = objectBuilder.createUnit()
         objectWithA.addComponent(TestComponentA())
-        objectWithA.addIntoInstance(instance, Position(5f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithA, instance, Position(5f, 5f, 0f, 0f))
 
         val objectWithB = objectBuilder.createUnit()
         objectWithB.addComponent(TestComponentB())
-        objectWithB.addIntoInstance(instance, Position(6f, 6f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithB, instance, Position(6f, 6f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -226,13 +226,13 @@ class GridTest {
         objectWithABC.addComponent(TestComponentA())
         objectWithABC.addComponent(TestComponentB())
         objectWithABC.addComponent(TestComponentC())
-        objectWithABC.addIntoInstance(instance, Position(5f, 5f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithABC, instance, Position(5f, 5f, 0f, 0f))
 
         // Object with only two components
         val objectWithAB = objectBuilder.createUnit()
         objectWithAB.addComponent(TestComponentA())
         objectWithAB.addComponent(TestComponentB())
-        objectWithAB.addIntoInstance(instance, Position(6f, 6f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectWithAB, instance, Position(6f, 6f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -264,17 +264,17 @@ class GridTest {
         // Object exactly at radius (distance = 5)
         val objectAtBoundary = objectBuilder.createUnit()
         objectAtBoundary.addComponent(TestComponentA())
-        objectAtBoundary.addIntoInstance(instance, Position(3f, 4f, 0f, 0f)) // 3-4-5 triangle
+        WorldBuilder.addIntoInstance(objectAtBoundary, instance, Position(3f, 4f, 0f, 0f)) // 3-4-5 triangle
 
         // Object just inside radius
         val objectInside = objectBuilder.createUnit()
         objectInside.addComponent(TestComponentA())
-        objectInside.addIntoInstance(instance, Position(2f, 2f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectInside, instance, Position(2f, 2f, 0f, 0f))
 
         // Object just outside radius
         val objectOutside = objectBuilder.createUnit()
         objectOutside.addComponent(TestComponentA())
-        objectOutside.addIntoInstance(instance, Position(4f, 4f, 0f, 0f))
+        WorldBuilder.addIntoInstance(objectOutside, instance, Position(4f, 4f, 0f, 0f))
 
         // Act
         val result = instance.grid.findObjectsWithComponentInRadius(origin, radius, TestComponentA::class)

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/GridTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/GridTest.kt
@@ -24,6 +24,8 @@ class TestComponentC
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GridTest {
 
+    private val worldBuilder = WorldBuilder()
+
     @ParameterizedTest
     @MethodSource("neighborCellDataProvider")
     fun `I must give the neighbor cells`(baseCellIndex: Int, neighbor: Array<Cell>) {
@@ -46,27 +48,27 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentInRadius should return only objects with specified component within radius`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         // Create objects with ComponentA
         val objectWithA1 = objectBuilder.createUnit()
         objectWithA1.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectWithA1, instance, Position(5f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithA1, instance, Position(5f, 5f, 0f, 0f))
 
         val objectWithA2 = objectBuilder.createUnit()
         objectWithA2.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectWithA2, instance, Position(8f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithA2, instance, Position(8f, 5f, 0f, 0f))
 
         // Create objects with ComponentB (not A)
         val objectWithB = objectBuilder.createUnit()
         objectWithB.addComponent(TestComponentB())
-        WorldBuilder.addIntoInstance(objectWithB, instance, Position(6f, 6f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithB, instance, Position(6f, 6f, 0f, 0f))
 
         // Create object with ComponentA but outside radius
         val objectWithAOutside = objectBuilder.createUnit()
         objectWithAOutside.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectWithAOutside, instance, Position(50f, 50f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithAOutside, instance, Position(50f, 50f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 5f
@@ -85,12 +87,12 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentInRadius should return empty list when no objects have the component`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         val objectWithB = objectBuilder.createUnit()
         objectWithB.addComponent(TestComponentB())
-        WorldBuilder.addIntoInstance(objectWithB, instance, Position(5f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithB, instance, Position(5f, 5f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -105,12 +107,12 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentInRadius should return empty list when objects are outside radius`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         val objectWithA = objectBuilder.createUnit()
         objectWithA.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectWithA, instance, Position(50f, 50f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithA, instance, Position(50f, 50f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 5f
@@ -125,30 +127,30 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentsInRadius should return only objects with all specified components within radius`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         // Object with both ComponentA and ComponentB
         val objectWithAB = objectBuilder.createUnit()
         objectWithAB.addComponent(TestComponentA())
         objectWithAB.addComponent(TestComponentB())
-        WorldBuilder.addIntoInstance(objectWithAB, instance, Position(5f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithAB, instance, Position(5f, 5f, 0f, 0f))
 
         // Object with only ComponentA
         val objectWithOnlyA = objectBuilder.createUnit()
         objectWithOnlyA.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectWithOnlyA, instance, Position(6f, 6f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithOnlyA, instance, Position(6f, 6f, 0f, 0f))
 
         // Object with only ComponentB
         val objectWithOnlyB = objectBuilder.createUnit()
         objectWithOnlyB.addComponent(TestComponentB())
-        WorldBuilder.addIntoInstance(objectWithOnlyB, instance, Position(7f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithOnlyB, instance, Position(7f, 5f, 0f, 0f))
 
         // Object with both components but outside radius
         val objectWithABOutside = objectBuilder.createUnit()
         objectWithABOutside.addComponent(TestComponentA())
         objectWithABOutside.addComponent(TestComponentB())
-        WorldBuilder.addIntoInstance(objectWithABOutside, instance, Position(50f, 50f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithABOutside, instance, Position(50f, 50f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 5f
@@ -172,12 +174,12 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentsInRadius should return empty list when given no components`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         val obj = objectBuilder.createUnit()
         obj.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(obj, instance, Position(5f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(obj, instance, Position(5f, 5f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -192,16 +194,16 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentsInRadius should delegate to findObjectsWithComponentInRadius when given single component`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         val objectWithA = objectBuilder.createUnit()
         objectWithA.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectWithA, instance, Position(5f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithA, instance, Position(5f, 5f, 0f, 0f))
 
         val objectWithB = objectBuilder.createUnit()
         objectWithB.addComponent(TestComponentB())
-        WorldBuilder.addIntoInstance(objectWithB, instance, Position(6f, 6f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithB, instance, Position(6f, 6f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -218,7 +220,7 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentsInRadius should handle three or more components correctly`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         // Object with all three components
@@ -226,13 +228,13 @@ class GridTest {
         objectWithABC.addComponent(TestComponentA())
         objectWithABC.addComponent(TestComponentB())
         objectWithABC.addComponent(TestComponentC())
-        WorldBuilder.addIntoInstance(objectWithABC, instance, Position(5f, 5f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithABC, instance, Position(5f, 5f, 0f, 0f))
 
         // Object with only two components
         val objectWithAB = objectBuilder.createUnit()
         objectWithAB.addComponent(TestComponentA())
         objectWithAB.addComponent(TestComponentB())
-        WorldBuilder.addIntoInstance(objectWithAB, instance, Position(6f, 6f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectWithAB, instance, Position(6f, 6f, 0f, 0f))
 
         val origin = Position(5f, 5f, 0f, 0f)
         val radius = 10f
@@ -255,7 +257,7 @@ class GridTest {
     @Test
     fun `findObjectsWithComponentInRadius should respect exact radius boundary`() {
         // Arrange
-        val instance = WorldBuilder.buildBasicWorld()
+        val instance = worldBuilder.buildBasicWorld()
         val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
         val origin = Position(0f, 0f, 0f, 0f)
@@ -264,17 +266,17 @@ class GridTest {
         // Object exactly at radius (distance = 5)
         val objectAtBoundary = objectBuilder.createUnit()
         objectAtBoundary.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectAtBoundary, instance, Position(3f, 4f, 0f, 0f)) // 3-4-5 triangle
+        worldBuilder.addIntoInstance(objectAtBoundary, instance, Position(3f, 4f, 0f, 0f)) // 3-4-5 triangle
 
         // Object just inside radius
         val objectInside = objectBuilder.createUnit()
         objectInside.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectInside, instance, Position(2f, 2f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectInside, instance, Position(2f, 2f, 0f, 0f))
 
         // Object just outside radius
         val objectOutside = objectBuilder.createUnit()
         objectOutside.addComponent(TestComponentA())
-        WorldBuilder.addIntoInstance(objectOutside, instance, Position(4f, 4f, 0f, 0f))
+        worldBuilder.addIntoInstance(objectOutside, instance, Position(4f, 4f, 0f, 0f))
 
         // Act
         val result = instance.grid.findObjectsWithComponentInRadius(origin, radius, TestComponentA::class)

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/chunk/ChunkManagerTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/chunk/ChunkManagerTest.kt
@@ -3,8 +3,6 @@ package fr.rob.game.test.unit.domain.game.world.grid.chunk
 import fr.rob.game.entity.Position
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.entity.guid.ObjectGuidGenerator
-import fr.rob.game.instance.MapInstance
-import fr.rob.game.map.grid.Grid
 import fr.rob.game.map.grid.GridBuilder
 import fr.rob.game.map.grid.GridConstraintChecker
 import fr.rob.game.map.grid.chunk.ChunkId
@@ -32,9 +30,10 @@ import org.junit.jupiter.api.Test
  */
 class ChunkManagerTest {
 
+    private val worldBuilder = WorldBuilder()
     private val grid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
     private val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
-    private val instance = createInstanceWithChunkManager(grid, chunkManager, 13)
+    private val instance = worldBuilder.buildInstanceWithChunkManager(grid, chunkManager, 13)
     private val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
 
     companion object {
@@ -55,17 +54,6 @@ class ChunkManagerTest {
 
         /** Cell (5,5) → chunk (1,1) — center of grid */
         fun posInChunk11() = Position(5f, 5f, 0f, 0f)
-
-        fun createInstanceWithChunkManager(grid: Grid, cm: ChunkManager, id: Int = 99): MapInstance {
-            val mapInfo = fr.rob.game.map.MapInfo("Test map", 200, 200)
-            val zoneInfo = fr.rob.game.map.ZoneInfo("Test zone", 100, 100, 0f, 0f)
-            val map = fr.rob.game.map.Map(1, 1, mapInfo, zoneInfo)
-
-            val instance = MapInstance(id, map, grid)
-            WorldBuilder.registerChunkManager(instance.id, cm)
-
-            return instance
-        }
     }
 
     // ──────────────────────────────────────────────
@@ -140,7 +128,7 @@ class ChunkManagerTest {
         @Test
         fun `player entering activates their chunk and neighbors`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val neighbors = chunkManager.getNeighborChunkIds(ChunkId(0, 0))
             for (chunk in neighbors) {
@@ -151,7 +139,7 @@ class ChunkManagerTest {
         @Test
         fun `player leaving starts shutdown on all nearby chunks`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             chunkManager.onPlayerLeft(player)
 
@@ -165,8 +153,8 @@ class ChunkManagerTest {
         fun `chunk stays active if second player is still present`() {
             val player1 = objectBuilder.createPlayer()
             val player2 = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player1, instance, posInChunk00())
-            WorldBuilder.addIntoInstance(player2, instance, posInChunk00Alt()) // same chunk (0,0), different cell
+            worldBuilder.addIntoInstance(player1, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player2, instance, posInChunk00Alt()) // same chunk (0,0), different cell
 
             chunkManager.onPlayerLeft(player1)
 
@@ -180,9 +168,9 @@ class ChunkManagerTest {
             val testGrid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
             val cm = ChunkManager(testGrid, 3, shutdownMs)
 
-            val testInstance = createInstanceWithChunkManager(testGrid, cm)
+            val testInstance = worldBuilder.buildInstanceWithChunkManager(testGrid, cm)
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, testInstance, posInChunk00())
+            worldBuilder.addIntoInstance(player, testInstance, posInChunk00())
 
             cm.onPlayerLeft(player)
             val chunkId = ChunkId(0, 0)
@@ -205,16 +193,16 @@ class ChunkManagerTest {
             val testGrid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
             val cm = ChunkManager(testGrid, 3, shutdownMs)
 
-            val testInstance = createInstanceWithChunkManager(testGrid, cm)
+            val testInstance = worldBuilder.buildInstanceWithChunkManager(testGrid, cm)
             val player1 = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player1, testInstance, posInChunk00())
+            worldBuilder.addIntoInstance(player1, testInstance, posInChunk00())
 
             cm.onPlayerLeft(player1)
             assertTrue(cm.getChunkState(ChunkId(0, 0)) is ChunkState.ShuttingDown)
 
             // New player enters the same chunk area
             val player2 = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player2, testInstance, posInChunk00())
+            worldBuilder.addIntoInstance(player2, testInstance, posInChunk00())
 
             assertEquals(ChunkState.Active, cm.getChunkState(ChunkId(0, 0)))
         }
@@ -229,7 +217,7 @@ class ChunkManagerTest {
         @Test
         fun `player count increments for chunk and all neighbors on enter`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val neighbors = chunkManager.getNeighborChunkIds(ChunkId(0, 0))
             for (chunk in neighbors) {
@@ -240,7 +228,7 @@ class ChunkManagerTest {
         @Test
         fun `player count decrements on leave`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             chunkManager.onPlayerLeft(player)
 
@@ -253,8 +241,8 @@ class ChunkManagerTest {
             val player2 = objectBuilder.createPlayer()
 
             // Both in adjacent chunks that share neighbor (1,1)
-            WorldBuilder.addIntoInstance(player1, instance, posInChunk00())   // chunk (0,0)
-            WorldBuilder.addIntoInstance(player2, instance, posInChunk11())   // chunk (1,1)
+            worldBuilder.addIntoInstance(player1, instance, posInChunk00())   // chunk (0,0)
+            worldBuilder.addIntoInstance(player2, instance, posInChunk11())   // chunk (1,1)
 
             // Chunk (1,1) is neighbor of both (0,0) and (1,1) → count = 2
             assertEquals(2, chunkManager.getPlayerCount(ChunkId(1, 1)))
@@ -270,7 +258,7 @@ class ChunkManagerTest {
         @Test
         fun `moving to a new chunk activates gained chunks and starts shutdown on lost chunks`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val oldChunkId = ChunkId(0, 0)
             val newChunkId = ChunkId(2, 2)
@@ -301,10 +289,10 @@ class ChunkManagerTest {
         @Test
         fun `entities in active chunks are returned by getActiveEntitiesByType`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt()) // same chunk area
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt()) // same chunk area
 
             val activeGameObjects = chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT).toList()
             assertTrue(activeGameObjects.contains(unit))
@@ -314,7 +302,7 @@ class ChunkManagerTest {
         fun `entities in dormant chunks are NOT returned by getActiveEntitiesByType`() {
             // No player → all chunks dormant
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00())
 
             val activeGameObjects = chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT).toList()
             assertTrue(activeGameObjects.isEmpty())
@@ -323,10 +311,10 @@ class ChunkManagerTest {
         @Test
         fun `entities in shutting-down chunks are still returned`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             // Player leaves → chunks start shutting down
             chunkManager.onPlayerLeft(player)
@@ -338,10 +326,10 @@ class ChunkManagerTest {
         @Test
         fun `unregistered entity is no longer returned`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             chunkManager.unregisterEntity(unit, unit.cachedChunkId!!)
 
@@ -359,10 +347,10 @@ class ChunkManagerTest {
         @Test
         fun `despawnChunkEntities removes non-player entities and marks them not in world`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             assertTrue(unit.isInWorld)
 
@@ -376,7 +364,7 @@ class ChunkManagerTest {
         @Test
         fun `despawnChunkEntities does not remove players`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val chunkId = chunkManager.getChunkIdForPosition(player.position)
             val despawned = chunkManager.despawnChunkEntities(chunkId)
@@ -388,10 +376,10 @@ class ChunkManagerTest {
         @Test
         fun `despawned entities are removed from the grid`() {
             val player = objectBuilder.createPlayer()
-            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
 
             val unit = objectBuilder.createUnit()
-            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+            worldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
 
             val chunkId = chunkManager.getChunkIdForPosition(unit.position)
             chunkManager.despawnChunkEntities(chunkId)

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/chunk/ChunkManagerTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/chunk/ChunkManagerTest.kt
@@ -1,0 +1,403 @@
+package fr.rob.game.test.unit.domain.game.world.grid.chunk
+
+import fr.rob.game.entity.Position
+import fr.rob.game.entity.guid.ObjectGuid
+import fr.rob.game.entity.guid.ObjectGuidGenerator
+import fr.rob.game.instance.MapInstance
+import fr.rob.game.map.grid.Grid
+import fr.rob.game.map.grid.GridBuilder
+import fr.rob.game.map.grid.GridConstraintChecker
+import fr.rob.game.map.grid.chunk.ChunkId
+import fr.rob.game.map.grid.chunk.ChunkManager
+import fr.rob.game.map.grid.chunk.ChunkState
+import fr.rob.game.test.unit.tools.DummyWorldObjectBuilder
+import fr.rob.game.test.unit.tools.WorldBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Test grid: 10x10 cells, cell size 10m, zone 100x100m.
+ * Chunk size: 3 cells => chunks (0,0)..(3,3).
+ *
+ * World origin (0,0) maps to zone center. With zone 100x100 and offset (0,0):
+ *   normalizedX = worldX + 50, cellX = ceil(normalizedX / 10) - 1
+ *
+ * Cell layout per chunk:
+ *   Chunk (0,0) = cells (0,0)-(2,2)
+ *   Chunk (1,0) = cells (3,0)-(5,2)
+ *   Chunk (3,3) = cell (9,9)
+ */
+class ChunkManagerTest {
+
+    private val grid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
+    private val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
+    private val instance = createInstanceWithChunkManager(grid, chunkManager, 13)
+    private val objectBuilder = DummyWorldObjectBuilder(ObjectGuidGenerator())
+
+    companion object {
+        // World positions that map to known cells/chunks.
+        // Formula: cellX = ceil((worldX + 50) / 10) - 1
+
+        /** Cell (0,0) → chunk (0,0) */
+        fun posInChunk00() = Position(-45f, -45f, 0f, 0f)
+
+        /** Cell (1,0) → chunk (0,0) — same chunk, different cell */
+        fun posInChunk00Alt() = Position(-35f, -45f, 0f, 0f)
+
+        /** Cell (3,0) → chunk (1,0) */
+        fun posInChunk10() = Position(-15f, -45f, 0f, 0f)
+
+        /** Cell (9,9) → chunk (3,3) */
+        fun posInChunk33() = Position(45f, 45f, 0f, 0f)
+
+        /** Cell (5,5) → chunk (1,1) — center of grid */
+        fun posInChunk11() = Position(5f, 5f, 0f, 0f)
+
+        fun createInstanceWithChunkManager(grid: Grid, cm: ChunkManager, id: Int = 99): MapInstance {
+            val mapInfo = fr.rob.game.map.MapInfo("Test map", 200, 200)
+            val zoneInfo = fr.rob.game.map.ZoneInfo("Test zone", 100, 100, 0f, 0f)
+            val map = fr.rob.game.map.Map(1, 1, mapInfo, zoneInfo)
+
+            val instance = MapInstance(id, map, grid)
+            WorldBuilder.registerChunkManager(instance.id, cm)
+
+            return instance
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Chunk ID calculation
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class ChunkIdCalculation {
+        @Test
+        fun `position in first cell maps to chunk (0,0)`() {
+            val chunkId = chunkManager.getChunkIdForPosition(posInChunk00())
+            assertEquals(ChunkId(0, 0), chunkId)
+        }
+
+        @Test
+        fun `position in cell (3,0) maps to chunk (1,0)`() {
+            val chunkId = chunkManager.getChunkIdForPosition(posInChunk10())
+            assertEquals(ChunkId(1, 0), chunkId)
+        }
+
+        @Test
+        fun `position in cell (9,9) maps to chunk (3,3)`() {
+            val chunkId = chunkManager.getChunkIdForPosition(posInChunk33())
+            assertEquals(ChunkId(3, 3), chunkId)
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Neighbor chunks
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class NeighborChunks {
+        @Test
+        fun `center chunk has 9 neighbors including itself`() {
+            val neighbors = chunkManager.getNeighborChunkIds(ChunkId(1, 1))
+            assertEquals(9, neighbors.size)
+            assertTrue(neighbors.contains(ChunkId(1, 1)))
+            assertTrue(neighbors.contains(ChunkId(0, 0)))
+            assertTrue(neighbors.contains(ChunkId(2, 2)))
+        }
+
+        @Test
+        fun `corner chunk (0,0) has 4 neighbors`() {
+            val neighbors = chunkManager.getNeighborChunkIds(ChunkId(0, 0))
+            assertEquals(4, neighbors.size)
+            assertTrue(neighbors.contains(ChunkId(0, 0)))
+            assertTrue(neighbors.contains(ChunkId(1, 0)))
+            assertTrue(neighbors.contains(ChunkId(0, 1)))
+            assertTrue(neighbors.contains(ChunkId(1, 1)))
+        }
+
+        @Test
+        fun `edge chunk (1,0) has 6 neighbors`() {
+            val neighbors = chunkManager.getNeighborChunkIds(ChunkId(1, 0))
+            assertEquals(6, neighbors.size)
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // State transitions: player enters / leaves
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class StateTransitions {
+        @Test
+        fun `all chunks are dormant by default`() {
+            assertEquals(ChunkState.Dormant, chunkManager.getChunkState(ChunkId(0, 0)))
+            assertEquals(ChunkState.Dormant, chunkManager.getChunkState(ChunkId(1, 1)))
+        }
+
+        @Test
+        fun `player entering activates their chunk and neighbors`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val neighbors = chunkManager.getNeighborChunkIds(ChunkId(0, 0))
+            for (chunk in neighbors) {
+                assertEquals(ChunkState.Active, chunkManager.getChunkState(chunk))
+            }
+        }
+
+        @Test
+        fun `player leaving starts shutdown on all nearby chunks`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            chunkManager.onPlayerLeft(player)
+
+            val neighbors = chunkManager.getNeighborChunkIds(ChunkId(0, 0))
+            for (chunk in neighbors) {
+                assertTrue(chunkManager.getChunkState(chunk) is ChunkState.ShuttingDown)
+            }
+        }
+
+        @Test
+        fun `chunk stays active if second player is still present`() {
+            val player1 = objectBuilder.createPlayer()
+            val player2 = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player1, instance, posInChunk00())
+            WorldBuilder.addIntoInstance(player2, instance, posInChunk00Alt()) // same chunk (0,0), different cell
+
+            chunkManager.onPlayerLeft(player1)
+
+            // player2 still holds the chunk active
+            assertEquals(ChunkState.Active, chunkManager.getChunkState(ChunkId(0, 0)))
+        }
+
+        @Test
+        fun `shutdown timer ticks down and transitions to dormant`() {
+            val shutdownMs = 1000
+            val testGrid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
+            val cm = ChunkManager(testGrid, 3, shutdownMs)
+
+            val testInstance = createInstanceWithChunkManager(testGrid, cm)
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, testInstance, posInChunk00())
+
+            cm.onPlayerLeft(player)
+            val chunkId = ChunkId(0, 0)
+            assertTrue(cm.getChunkState(chunkId) is ChunkState.ShuttingDown)
+
+            // Tick 500ms — still shutting down
+            val dormant1 = cm.update(500)
+            assertTrue(dormant1.isEmpty())
+            assertTrue(cm.getChunkState(chunkId) is ChunkState.ShuttingDown)
+
+            // Tick 500ms more — now dormant
+            val dormant2 = cm.update(500)
+            assertTrue(dormant2.contains(chunkId))
+            assertEquals(ChunkState.Dormant, cm.getChunkState(chunkId))
+        }
+
+        @Test
+        fun `reactivating a shutting-down chunk cancels the shutdown`() {
+            val shutdownMs = 5000
+            val testGrid = GridBuilder(GridConstraintChecker()).buildGrid(10, 100, 100)
+            val cm = ChunkManager(testGrid, 3, shutdownMs)
+
+            val testInstance = createInstanceWithChunkManager(testGrid, cm)
+            val player1 = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player1, testInstance, posInChunk00())
+
+            cm.onPlayerLeft(player1)
+            assertTrue(cm.getChunkState(ChunkId(0, 0)) is ChunkState.ShuttingDown)
+
+            // New player enters the same chunk area
+            val player2 = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player2, testInstance, posInChunk00())
+
+            assertEquals(ChunkState.Active, cm.getChunkState(ChunkId(0, 0)))
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Player counting
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class PlayerCounting {
+        @Test
+        fun `player count increments for chunk and all neighbors on enter`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val neighbors = chunkManager.getNeighborChunkIds(ChunkId(0, 0))
+            for (chunk in neighbors) {
+                assertEquals(1, chunkManager.getPlayerCount(chunk))
+            }
+        }
+
+        @Test
+        fun `player count decrements on leave`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            chunkManager.onPlayerLeft(player)
+
+            assertEquals(0, chunkManager.getPlayerCount(ChunkId(0, 0)))
+        }
+
+        @Test
+        fun `overlapping neighbors accumulate player counts`() {
+            val player1 = objectBuilder.createPlayer()
+            val player2 = objectBuilder.createPlayer()
+
+            // Both in adjacent chunks that share neighbor (1,1)
+            WorldBuilder.addIntoInstance(player1, instance, posInChunk00())   // chunk (0,0)
+            WorldBuilder.addIntoInstance(player2, instance, posInChunk11())   // chunk (1,1)
+
+            // Chunk (1,1) is neighbor of both (0,0) and (1,1) → count = 2
+            assertEquals(2, chunkManager.getPlayerCount(ChunkId(1, 1)))
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Player chunk change
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class PlayerChunkChange {
+        @Test
+        fun `moving to a new chunk activates gained chunks and starts shutdown on lost chunks`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val oldChunkId = ChunkId(0, 0)
+            val newChunkId = ChunkId(2, 2)
+
+            chunkManager.onPlayerChunkChanged(oldChunkId, newChunkId)
+
+            // New chunk's neighbors should be active
+            val newNeighbors = chunkManager.getNeighborChunkIds(newChunkId)
+            for (chunk in newNeighbors) {
+                assertEquals(ChunkState.Active, chunkManager.getChunkState(chunk))
+            }
+
+            // Old exclusive neighbors should be shutting down
+            val oldNeighbors = chunkManager.getNeighborChunkIds(oldChunkId)
+            val lostChunks = oldNeighbors - newNeighbors.toSet()
+            for (chunk in lostChunks) {
+                assertTrue(chunkManager.getChunkState(chunk) is ChunkState.ShuttingDown)
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Entity registration & active entity iteration
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class EntityIteration {
+        @Test
+        fun `entities in active chunks are returned by getActiveEntitiesByType`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt()) // same chunk area
+
+            val activeGameObjects = chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT).toList()
+            assertTrue(activeGameObjects.contains(unit))
+        }
+
+        @Test
+        fun `entities in dormant chunks are NOT returned by getActiveEntitiesByType`() {
+            // No player → all chunks dormant
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00())
+
+            val activeGameObjects = chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT).toList()
+            assertTrue(activeGameObjects.isEmpty())
+        }
+
+        @Test
+        fun `entities in shutting-down chunks are still returned`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            // Player leaves → chunks start shutting down
+            chunkManager.onPlayerLeft(player)
+
+            val activeGameObjects = chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT).toList()
+            assertTrue(activeGameObjects.contains(unit))
+        }
+
+        @Test
+        fun `unregistered entity is no longer returned`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            chunkManager.unregisterEntity(unit, unit.cachedChunkId!!)
+
+            val activeGameObjects = chunkManager.getActiveEntitiesByType(ObjectGuid.GUID_TYPE.GAME_OBJECT).toList()
+            assertFalse(activeGameObjects.contains(unit))
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Despawn
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class Despawn {
+        @Test
+        fun `despawnChunkEntities removes non-player entities and marks them not in world`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            assertTrue(unit.isInWorld)
+
+            val chunkId = chunkManager.getChunkIdForPosition(unit.position)
+            val despawned = chunkManager.despawnChunkEntities(chunkId)
+
+            assertTrue(despawned.contains(unit))
+            assertFalse(unit.isInWorld)
+        }
+
+        @Test
+        fun `despawnChunkEntities does not remove players`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val chunkId = chunkManager.getChunkIdForPosition(player.position)
+            val despawned = chunkManager.despawnChunkEntities(chunkId)
+
+            assertFalse(despawned.contains(player))
+            assertTrue(player.isInWorld)
+        }
+
+        @Test
+        fun `despawned entities are removed from the grid`() {
+            val player = objectBuilder.createPlayer()
+            WorldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            val unit = objectBuilder.createUnit()
+            WorldBuilder.addIntoInstance(unit, instance, posInChunk00Alt())
+
+            val chunkId = chunkManager.getChunkIdForPosition(unit.position)
+            chunkManager.despawnChunkEntities(chunkId)
+
+            val found = instance.grid.findObjectByGuid(unit.guid)
+            assertEquals(null, found)
+        }
+    }
+}

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/chunk/ChunkManagerTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/game/world/grid/chunk/ChunkManagerTest.kt
@@ -247,6 +247,25 @@ class ChunkManagerTest {
             // Chunk (1,1) is neighbor of both (0,0) and (1,1) → count = 2
             assertEquals(2, chunkManager.getPlayerCount(ChunkId(1, 1)))
         }
+
+        @Test
+        fun `onPlayerLeft uses cachedChunkId even if position has drifted`() {
+            // Regression: onPlayerLeft must decrement the chunk where the player
+            // was registered (cachedChunkId), not where position happens to be now.
+            val player = objectBuilder.createPlayer()
+            worldBuilder.addIntoInstance(player, instance, posInChunk00())
+
+            // Simulate position drift without a chunk change event having been
+            // processed yet (e.g. a movement happened just before despawn).
+            player.position = posInChunk33()
+
+            chunkManager.onPlayerLeft(player)
+
+            // (0,0) and its neighbors must be decremented, NOT (3,3)'s neighbors.
+            for (chunk in chunkManager.getNeighborChunkIds(ChunkId(0, 0))) {
+                assertEquals(0, chunkManager.getPlayerCount(chunk))
+            }
+        }
     }
 
     // ──────────────────────────────────────────────

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/spell/AoeSpellTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/spell/AoeSpellTest.kt
@@ -45,25 +45,25 @@ class AoeSpellTest : SpellCasterEnvironmentBaseTest() {
         assertEquals(100, target.getComponent<HealthComponent>()?.value)
 
         // Let's jump after the first tick
-        instance.update(500, eventDispatcher)
+        instanceUpdateService.update(instance, 500, eventDispatcher)
 
         assertEquals(90, caster.getComponent<HealthComponent>()?.value)
         assertEquals(90, target.getComponent<HealthComponent>()?.value)
 
         // Let's jump 200 ms => the second tick is not ready yet, no changes
-        instance.update(200, eventDispatcher)
+        instanceUpdateService.update(instance, 200, eventDispatcher)
 
         assertEquals(90, caster.getComponent<HealthComponent>()?.value)
         assertEquals(90, target.getComponent<HealthComponent>()?.value)
 
         // Let's jump 400 ms => the second tick is past since 100ms
-        instance.update(400, eventDispatcher)
+        instanceUpdateService.update(instance, 400, eventDispatcher)
 
         assertEquals(80, caster.getComponent<HealthComponent>()?.value)
         assertEquals(80, target.getComponent<HealthComponent>()?.value)
 
         // Let's jump 400 ms => the script should be ending
-        instance.update(400, eventDispatcher)
+        instanceUpdateService.update(instance, 400, eventDispatcher)
 
         assertEquals(80, caster.getComponent<HealthComponent>()?.value)
         assertEquals(80, target.getComponent<HealthComponent>()?.value)

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/spell/SpellCasterEnvironmentBaseTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/spell/SpellCasterEnvironmentBaseTest.kt
@@ -10,7 +10,6 @@ import fr.rob.game.instance.InstanceManager
 import fr.rob.game.instance.InstanceUpdateService
 import fr.rob.game.map.grid.GridBuilder
 import fr.rob.game.map.grid.GridConstraintChecker
-import fr.rob.game.map.grid.chunk.ChunkManager
 import fr.rob.game.spell.SpellBook
 import fr.rob.game.spell.SpellCasterTrait
 import fr.rob.game.test.unit.tools.RiggedDiceEngine
@@ -22,10 +21,10 @@ abstract class SpellCasterEnvironmentBaseTest {
     protected lateinit var caster: WorldUnit
     protected lateinit var target: WorldUnit
     protected val targetRiggedDiceEngine = RiggedDiceEngine()
-    protected val instance = WorldBuilder.buildBasicWorld()
+    protected val worldBuilder = WorldBuilder()
+    protected val instance = worldBuilder.buildBasicWorld()
     private val testInstanceManager = InstanceManager(GridBuilder(GridConstraintChecker())).also { im ->
-        val cm = ChunkManager(instance.grid, ChunkManager.DEFAULT_CHUNK_SIZE)
-        im.registerChunkManager(instance.id, cm)
+        im.registerChunkManager(instance.id, worldBuilder.getChunkManager(instance.id)!!)
     }
     protected val instanceUpdateService = InstanceUpdateService(testInstanceManager)
 
@@ -54,7 +53,7 @@ abstract class SpellCasterEnvironmentBaseTest {
         )
         unitToCreate.addComponent(HealthComponent(100))
         unitToCreate.addBehavior(ObjectSheetBehavior(targetRiggedDiceEngine))
-        WorldBuilder.addIntoInstance(unitToCreate, instance, position)
+        worldBuilder.addIntoInstance(unitToCreate, instance, position)
 
         return unitToCreate
     }

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/spell/SpellCasterEnvironmentBaseTest.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/domain/spell/SpellCasterEnvironmentBaseTest.kt
@@ -6,6 +6,11 @@ import fr.rob.game.entity.ObjectManager
 import fr.rob.game.entity.Position
 import fr.rob.game.entity.guid.ObjectGuid
 import fr.rob.game.entity.guid.ObjectGuidGenerator
+import fr.rob.game.instance.InstanceManager
+import fr.rob.game.instance.InstanceUpdateService
+import fr.rob.game.map.grid.GridBuilder
+import fr.rob.game.map.grid.GridConstraintChecker
+import fr.rob.game.map.grid.chunk.ChunkManager
 import fr.rob.game.spell.SpellBook
 import fr.rob.game.spell.SpellCasterTrait
 import fr.rob.game.test.unit.tools.RiggedDiceEngine
@@ -18,10 +23,15 @@ abstract class SpellCasterEnvironmentBaseTest {
     protected lateinit var target: WorldUnit
     protected val targetRiggedDiceEngine = RiggedDiceEngine()
     protected val instance = WorldBuilder.buildBasicWorld()
+    private val testInstanceManager = InstanceManager(GridBuilder(GridConstraintChecker())).also { im ->
+        val cm = ChunkManager(instance.grid, ChunkManager.DEFAULT_CHUNK_SIZE)
+        im.registerChunkManager(instance.id, cm)
+    }
+    protected val instanceUpdateService = InstanceUpdateService(testInstanceManager)
 
     private lateinit var spellBook: SpellBook
     private val guidGenerator = ObjectGuidGenerator()
-    private val objectManager = ObjectManager(guidGenerator)
+    private val objectManager = ObjectManager(guidGenerator, testInstanceManager)
     private var entryGuid: UInt = 1u
 
     @BeforeEach
@@ -44,7 +54,7 @@ abstract class SpellCasterEnvironmentBaseTest {
         )
         unitToCreate.addComponent(HealthComponent(100))
         unitToCreate.addBehavior(ObjectSheetBehavior(targetRiggedDiceEngine))
-        unitToCreate.addIntoInstance(instance, position)
+        WorldBuilder.addIntoInstance(unitToCreate, instance, position)
 
         return unitToCreate
     }

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/tools/WorldBuilder.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/tools/WorldBuilder.kt
@@ -1,22 +1,56 @@
 package fr.rob.game.test.unit.tools
 
+import fr.rob.game.entity.Position
+import fr.rob.game.entity.WorldObject
+import fr.rob.game.entity.event.AddedIntoWorldEvent
 import fr.rob.game.instance.MapInstance
 import fr.rob.game.map.grid.GridBuilder
 import fr.rob.game.map.grid.GridConstraintChecker
+import fr.rob.game.map.grid.chunk.ChunkManager
 import fr.rob.game.map.Map
 import fr.rob.game.map.MapInfo
 import fr.rob.game.map.ZoneInfo
 
 class WorldBuilder {
     companion object {
+        private val chunkManagers = mutableMapOf<Int, ChunkManager>()
+
         fun buildBasicWorld(): MapInstance {
             val mapInfo = MapInfo("A testing map", 200, 200)
             val zoneInfo = ZoneInfo("A testing zone", 100, 100, 0f, 0f)
             val map = Map(1, 1, mapInfo, zoneInfo)
             val gridBuilder = GridBuilder(GridConstraintChecker())
             val grid = gridBuilder.buildGrid(10, zoneInfo.width, zoneInfo.height)
+            val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
 
-            return MapInstance(13, map, grid)
+            val instance = MapInstance(13, map, grid)
+            chunkManagers[instance.id] = chunkManager
+
+            return instance
+        }
+
+        fun addIntoInstance(worldObject: WorldObject, instance: MapInstance, position: Position) {
+            worldObject.mapInstance = instance
+            worldObject.position = position
+            worldObject.isInWorld = true
+
+            instance.pushEvent(AddedIntoWorldEvent(worldObject))
+            instance.grid.addWorldObject(worldObject)
+
+            val chunkManager = chunkManagers[instance.id]
+            if (chunkManager != null) {
+                val chunkId = chunkManager.getChunkIdForPosition(position)
+                worldObject.cachedChunkId = chunkId
+                chunkManager.registerEntity(worldObject, chunkId)
+
+                if (worldObject.guid.isPlayer()) {
+                    chunkManager.onPlayerEntered(worldObject)
+                }
+            }
+        }
+
+        fun registerChunkManager(instanceId: Int, chunkManager: ChunkManager) {
+            chunkManagers[instanceId] = chunkManager
         }
     }
 }

--- a/servers/game/src/test/kotlin/fr/rob/game/test/unit/tools/WorldBuilder.kt
+++ b/servers/game/src/test/kotlin/fr/rob/game/test/unit/tools/WorldBuilder.kt
@@ -4,6 +4,7 @@ import fr.rob.game.entity.Position
 import fr.rob.game.entity.WorldObject
 import fr.rob.game.entity.event.AddedIntoWorldEvent
 import fr.rob.game.instance.MapInstance
+import fr.rob.game.map.grid.Grid
 import fr.rob.game.map.grid.GridBuilder
 import fr.rob.game.map.grid.GridConstraintChecker
 import fr.rob.game.map.grid.chunk.ChunkManager
@@ -11,46 +12,60 @@ import fr.rob.game.map.Map
 import fr.rob.game.map.MapInfo
 import fr.rob.game.map.ZoneInfo
 
-class WorldBuilder {
-    companion object {
-        private val chunkManagers = mutableMapOf<Int, ChunkManager>()
+class WorldBuilder(
+    private val shutdownMs: Int = ChunkManager.DEFAULT_SHUTDOWN_DURATION_MS,
+    private val chunkSize: Int = ChunkManager.DEFAULT_CHUNK_SIZE,
+) {
+    private val chunkManagers = mutableMapOf<Int, ChunkManager>()
 
-        fun buildBasicWorld(): MapInstance {
-            val mapInfo = MapInfo("A testing map", 200, 200)
-            val zoneInfo = ZoneInfo("A testing zone", 100, 100, 0f, 0f)
-            val map = Map(1, 1, mapInfo, zoneInfo)
-            val gridBuilder = GridBuilder(GridConstraintChecker())
-            val grid = gridBuilder.buildGrid(10, zoneInfo.width, zoneInfo.height)
-            val chunkManager = ChunkManager(grid, ChunkManager.DEFAULT_CHUNK_SIZE)
+    fun buildBasicWorld(): MapInstance {
+        val mapInfo = MapInfo("A testing map", 200, 200)
+        val zoneInfo = ZoneInfo("A testing zone", 100, 100, 0f, 0f)
+        val map = Map(1, 1, mapInfo, zoneInfo)
+        val gridBuilder = GridBuilder(GridConstraintChecker())
+        val grid = gridBuilder.buildGrid(10, zoneInfo.width, zoneInfo.height)
+        val chunkManager = ChunkManager(grid, chunkSize, shutdownMs)
 
-            val instance = MapInstance(13, map, grid)
-            chunkManagers[instance.id] = chunkManager
+        val instance = MapInstance(13, map, grid)
+        chunkManagers[instance.id] = chunkManager
 
-            return instance
-        }
+        return instance
+    }
 
-        fun addIntoInstance(worldObject: WorldObject, instance: MapInstance, position: Position) {
-            worldObject.mapInstance = instance
-            worldObject.position = position
-            worldObject.isInWorld = true
+    fun buildInstanceWithChunkManager(
+        grid: Grid,
+        chunkManager: ChunkManager,
+        instanceId: Int = 99,
+    ): MapInstance {
+        val mapInfo = MapInfo("Test map", 200, 200)
+        val zoneInfo = ZoneInfo("Test zone", 100, 100, 0f, 0f)
+        val map = Map(1, 1, mapInfo, zoneInfo)
 
-            instance.pushEvent(AddedIntoWorldEvent(worldObject))
-            instance.grid.addWorldObject(worldObject)
+        val instance = MapInstance(instanceId, map, grid)
+        chunkManagers[instanceId] = chunkManager
 
-            val chunkManager = chunkManagers[instance.id]
-            if (chunkManager != null) {
-                val chunkId = chunkManager.getChunkIdForPosition(position)
-                worldObject.cachedChunkId = chunkId
-                chunkManager.registerEntity(worldObject, chunkId)
+        return instance
+    }
 
-                if (worldObject.guid.isPlayer()) {
-                    chunkManager.onPlayerEntered(worldObject)
-                }
+    fun addIntoInstance(worldObject: WorldObject, instance: MapInstance, position: Position) {
+        worldObject.mapInstance = instance
+        worldObject.position = position
+        worldObject.isInWorld = true
+
+        instance.pushEvent(AddedIntoWorldEvent(worldObject))
+        instance.grid.addWorldObject(worldObject)
+
+        val chunkManager = chunkManagers[instance.id]
+        if (chunkManager != null) {
+            val chunkId = chunkManager.getChunkIdForPosition(position)
+            worldObject.cachedChunkId = chunkId
+            chunkManager.registerEntity(worldObject, chunkId)
+
+            if (worldObject.guid.isPlayer()) {
+                chunkManager.onPlayerEntered(worldObject)
             }
         }
-
-        fun registerChunkManager(instanceId: Int, chunkManager: ChunkManager) {
-            chunkManagers[instanceId] = chunkManager
-        }
     }
+
+    fun getChunkManager(instanceId: Int): ChunkManager? = chunkManagers[instanceId]
 }


### PR DESCRIPTION
Implement hybrid chunk system that groups grid cells into chunks and only updates entities in active chunks (near players). Chunks transition through Active → ShuttingDown (5min) → Dormant (entities despawned).

- Add ChunkId, ChunkState, ChunkManager, ChunkTransitionListener
- Add InstanceUpdateService to orchestrate the tick loop
- Move entity placement from WorldObject.addIntoInstance() to ObjectManager.addEntityIntoInstance() (entities are pure data)
- Remove MapInstance.onEntityAdded callback and related dead code
- Fix chunk transition bug: register/unregister now take explicit ChunkId to avoid using stale position after movement
- Add integration test for player movement across chunk boundaries